### PR TITLE
[FIX] 사진신고 오류 해결 및 이미지뷰 리팩터링(#49)

### DIFF
--- a/Genti_iOS/Genti_iOS/Complete/ViewModel/PhotoCompleteViewViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Complete/ViewModel/PhotoCompleteViewViewModel.swift
@@ -32,11 +32,7 @@ final class PhotoCompleteViewViewModel: ViewModel {
         var reportContent: String = ""
         var isLoading: Bool = false
         var showRatingView: Bool = false
-        var showAlert: AlertType? = nil {
-            didSet {
-                self.reportContent = ""
-            }
-        }
+        var showAlert: AlertType? = nil
     }
 
     enum Input {
@@ -51,17 +47,11 @@ final class PhotoCompleteViewViewModel: ViewModel {
     func sendAction(_ input: Input) {
         switch input {
         case .goToMainButtonTap:
-            showRatingView()
+            self.state.showRatingView = true
         case .reportButtonTap:
             presentReportAlert()
         case .imageTap:
             navigateToPhotoExpandView()
-//        case .ratingViewSkipButtonTap:
-//            dismissRatingView()
-//        case .ratingViewSubmitButtonTap:
-//            submitRating()
-//        case .ratingViewStarTap(let rating):
-//            updateRating(rating)
         case .viewWillAppear:
             Task {
                 do {
@@ -87,10 +77,6 @@ final class PhotoCompleteViewViewModel: ViewModel {
         }
     }
 
-    private func showRatingView() {
-        state.showRatingView = true
-    }
-
     private func presentReportAlert() {
         state.showAlert = .report(
             action: { [weak self] in
@@ -110,9 +96,11 @@ final class PhotoCompleteViewViewModel: ViewModel {
                 await MainActor.run {
                     state.isLoading = true
                 }
+                print(self.state.reportContent)
                 _ = try await userRepository.reportPhoto(id: self.photoInfo.id, content: self.state.reportContent)
                 await MainActor.run {
                     state.isLoading = false
+                    state.reportContent = ""
                     state.showAlert = .reportComplete
                 }
             } catch {
@@ -124,23 +112,6 @@ final class PhotoCompleteViewViewModel: ViewModel {
     private func navigateToPhotoExpandView() {
         guard let image = state.image else { return }
         self.router.routeTo(.photoDetail(image: image))
-    }
-
-    private func dismissRatingView() {
-        router.dismissSheet()
-    }
-
-    private func submitRating() {
-        Task {
-            state.isLoading = true
-            try await Task.sleep(nanoseconds: 1_000_000_000)
-            state.isLoading = false
-            router.dismissSheet()
-        }
-    }
-
-    private func updateRating(_ rating: Int) {
-//        state.rating = rating
     }
     
     var getImage: Image {

--- a/Genti_iOS/Genti_iOS/Complete/ViewModel/PhotoCompleteViewViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Complete/ViewModel/PhotoCompleteViewViewModel.swift
@@ -96,11 +96,10 @@ final class PhotoCompleteViewViewModel: ViewModel {
                 await MainActor.run {
                     state.isLoading = true
                 }
-                print(self.state.reportContent)
                 _ = try await userRepository.reportPhoto(id: self.photoInfo.id, content: self.state.reportContent)
                 await MainActor.run {
-                    state.isLoading = false
                     state.reportContent = ""
+                    state.isLoading = false
                     state.showAlert = .reportComplete
                 }
             } catch {

--- a/Genti_iOS/Genti_iOS/Generator/Models/PhotoRatio.swift
+++ b/Genti_iOS/Genti_iOS/Generator/Models/PhotoRatio.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum PhotoRatio {
-    case twoThird, threeSecond
+    case twoThird, threeSecond, square
     
     static var selections: [PhotoRatio] {
         return [.threeSecond, .twoThird]
@@ -20,6 +20,8 @@ enum PhotoRatio {
             return 3/2
         case .threeSecond:
             return 2/3
+        case .square:
+            return 1
         }
     }
     
@@ -29,6 +31,8 @@ enum PhotoRatio {
             return "Ratio_23"
         case .threeSecond:
             return "Ratio_32"
+        case .square:
+            return ""
         }
     }
     
@@ -38,6 +42,8 @@ enum PhotoRatio {
             return "RATIO_2_3"
         case .threeSecond:
             return "RATIO_3_2"
+        case .square:
+            return ""
         }
     }
     
@@ -47,6 +53,8 @@ enum PhotoRatio {
             "2:3 비율\n(가로로 긴 사진)"
         case .threeSecond:
             "3:2 비율\n(세로로 긴 사진)"
+        case .square:
+            ""
         }
     }
     

--- a/Genti_iOS/Genti_iOS/Home/Components/FeedComponent.swift
+++ b/Genti_iOS/Genti_iOS/Home/Components/FeedComponent.swift
@@ -26,7 +26,7 @@ struct FeedComponent: View {
     }
     
     private func mainImageView() -> some View {
-        ImageLoaderView(urlString: mainImage, ratio: ratio, width: Constants.screenWidth - 32)
+        ImageLoaderView(urlString: mainImage, ratio: ratio)
             .cornerRadiusWithBorder(style: Color.gentiGreen, radius: 15, lineWidth: 1)
     }
     private func photoDescriptionView() -> some View {

--- a/Genti_iOS/Genti_iOS/PhotoDetail/PhotoDetailWithShareView.swift
+++ b/Genti_iOS/Genti_iOS/PhotoDetail/PhotoDetailWithShareView.swift
@@ -11,26 +11,23 @@ struct PhotoDetailWithShareView: View {
     @State var viewModel: PhotoDetailViewModel
 
     var body: some View {
-        GeometryReader { geometry in
-            let padding: CGFloat = 30
-            let width = geometry.size.width - (2*padding)
-            let height = width * 1.5
-            VStack(spacing: 20) {
-                Image(uiImage: viewModel.state.image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .addDownloadButton {
-                        viewModel.sendAction(.downloadButtonTap) }
-                    .frame(width: width, height: height)
-
-                
-                
-                ShareLink(item: Image(uiImage: viewModel.state.image), preview: .init("내 사진", image: Image(uiImage: viewModel.state.image))) {
-                    Text("공유하기")
-                        .shareStyle()
+        VStack(spacing: 20) {
+            Rectangle()
+                .aspectRatio(1/1.5, contentMode: .fit)
+                .overlay(alignment: .center) {
+                    Image(uiImage: viewModel.state.image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .addDownloadButton {
+                            viewModel.sendAction(.downloadButtonTap) }
                 }
+                .padding(.horizontal, 30)
+            
+            ShareLink(item: Image(uiImage: viewModel.state.image), preview: .init("내 사진", image: Image(uiImage: viewModel.state.image))) {
+                Text("공유하기")
+                    .shareStyle()
             }
-            .frame(width: geometry.size.width, height: geometry.size.height, alignment: .center)
+            
         }
         .addXmark(top: 3, trailing: 20) { viewModel.sendAction(.xmarkTap) }
         .presentationBackground {

--- a/Genti_iOS/Genti_iOS/PopUp/ViewModel/RatingAlertViewModel.swift
+++ b/Genti_iOS/Genti_iOS/PopUp/ViewModel/RatingAlertViewModel.swift
@@ -41,7 +41,7 @@ final class RatingAlertViewModel: ViewModel {
                         self.state.isLoading = true
                     }
                     try await Task.sleep(nanoseconds: 1000000000)
-                    try await userRepository.ratePhoto(rate: state.rating)
+                    try await userRepository.scorePhoto(rate: state.rating)
                     
                     await MainActor.run {
                         self.state.isLoading = false

--- a/Genti_iOS/Genti_iOS/Profile/ProfileView.swift
+++ b/Genti_iOS/Genti_iOS/Profile/ProfileView.swift
@@ -7,73 +7,81 @@
 
 import SwiftUI
 
+import SDWebImageSwiftUI
+
 struct ProfileView: View {
  
     @State var viewModel: ProfileViewModel
     
     var body: some View {
-        GeometryReader { geometry in
-                VStack {
-                    HStack {
-                        Text("마이페이지")
-                            .pretendard(.headline1)
-                            .foregroundStyle(.black)
-                        Spacer()
-                        Image("Setting")
-                            .onTapGesture {
-                                viewModel.sendAction(.gearButtonTap)
-                            }
+        VStack {
+            HStack {
+                Text("마이페이지")
+                    .pretendard(.headline1)
+                    .foregroundStyle(.black)
+                Spacer()
+                Image("Setting")
+                    .onTapGesture {
+                        viewModel.sendAction(.gearButtonTap)
                     }
-                    .padding(.horizontal, 27)
-                    .padding(.vertical, 46)
-                    
-                    
-                    if viewModel.state.hasInProgressImage {
-                        BlurView(style: .light)
-                            .clipShape(.rect(cornerRadius: 18))
-                            .frame(height: 75)
-                            .padding(.horizontal, 16)
-                            .shadow(type: .soft)
-                            .overlay(alignment: .center) {
-                                Text("세상에 없던 나만의 사진 찍는중...")
-                                    .pretendard(.large)
-                                    .foregroundStyle(.black)
-                            }
-                            .padding(.bottom, 20)
-                    }
-                    
-                    VStack(spacing: 0) {
-                        BlurView(style: .light)
-                            .cornerRadius(10, corners: [.topLeft, .topRight])
-                            .frame(height: 50)
-                            .overlay(alignment: .center) {
-                                Text("내가 만든 사진")
-                                    .pretendard(.normal)
-                                    .foregroundStyle(.black)
-                            }
-                        
-                        Rectangle()
-                            .fill(.gray6)
-                            .frame(height: 2)
-                        
-                        StraggeredGrid(list: viewModel.state.myImages, spacing: 1) { object in
-                            ImageLoaderView(urlString: object.imageURL, ratio: object.ratio, width: (geometry.size.width-1)/2)
-                                .onTapGesture {
-                                    viewModel.sendAction(.imageTap(object.imageURL))
-                                }
-                                .onAppear {
-                                    guard let index = viewModel.state.myImages.firstIndex(where: { $0.id == object.id }) else { return }
-                                    
-                                    if index == viewModel.state.myImages.count - 1 {
-                                        viewModel.sendAction(.reachBottom)
-                                    }
-                                }
-                        }
-
-                    }
+            }
+            .padding(.horizontal, 27)
+            .padding(.vertical, 46)
+            
+            
+            if viewModel.state.hasInProgressImage {
+                BlurView(style: .light)
+                    .clipShape(.rect(cornerRadius: 18))
+                    .frame(height: 75)
+                    .padding(.horizontal, 16)
                     .shadow(type: .soft)
+                    .overlay(alignment: .center) {
+                        Text("세상에 없던 나만의 사진 찍는중...")
+                            .pretendard(.large)
+                            .foregroundStyle(.black)
+                    }
+                    .padding(.bottom, 20)
+            }
+            
+            VStack(spacing: 0) {
+                BlurView(style: .light)
+                    .cornerRadius(10, corners: [.topLeft, .topRight])
+                    .frame(height: 50)
+                    .overlay(alignment: .center) {
+                        Text("내가 만든 사진")
+                            .pretendard(.normal)
+                            .foregroundStyle(.black)
+                    }
+                
+                Rectangle()
+                    .fill(.gray6)
+                    .frame(height: 2)
+                
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVGrid(columns: [GridItem(.flexible(), spacing: 1),GridItem(.flexible(), spacing: 1),GridItem(.flexible(), spacing: 1)], spacing: 1) {
+                            ForEach(viewModel.state.myImages) { image in
+                                ImageLoaderView(urlString: image.imageURL, resizingMode: .fill, ratio: .square)
+                                    .onTapGesture {
+                                        viewModel.sendAction(.imageTap(image.imageURL))
+                                    }
+                                    .onAppear {
+                                        if image == viewModel.state.myImages.last {
+                                            viewModel.sendAction(.reachBottom)
+                                        }
+                                    }
+                                    .id(image.id)
+                            }
+                        }
+                    }
+                    .onAppear {
+                        guard let firstId = viewModel.state.myImages.first?.id else { return }
+                        proxy.scrollTo(firstId, anchor: .top)
+                    }
                 }
-            .frame(width: geometry.size.width, height: geometry.size.height)
+
+            }
+            .shadow(type: .soft)
         }
         .background {
             ZStack {

--- a/Genti_iOS/Genti_iOS/Profile/Repository/UserRepository.swift
+++ b/Genti_iOS/Genti_iOS/Profile/Repository/UserRepository.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 protocol UserRepository {
-    func getMyPictures(page: Int) async throws -> MyImagesEntitiy
-    func checkInProgress() async throws -> Bool
+    func fetchPhotos(page: Int) async throws -> MyImagesEntitiy
+    func checkUserStatus() async throws -> Bool
     func reportPhoto(id: Int, content: String) async throws
-    func ratePhoto(rate: Int) async throws
+    func scorePhoto(rate: Int) async throws
 }

--- a/Genti_iOS/Genti_iOS/Profile/Repository/UserRepositoryImpl.swift
+++ b/Genti_iOS/Genti_iOS/Profile/Repository/UserRepositoryImpl.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 final class UserRepositoryImpl: UserRepository {
-    func ratePhoto(rate: Int) async throws {}
-    
 
     let requestService: RequestService
     
@@ -17,16 +15,20 @@ final class UserRepositoryImpl: UserRepository {
         self.requestService = requestService
     }
     
-    func getMyPictures(page: Int) async throws -> MyImagesEntitiy {
+    func fetchPhotos(page: Int) async throws -> MyImagesEntitiy {
         let dto: PageCommonPictureResponseDTO = try await requestService.fetchResponse(for: UserRouter.fetchMyPictures(page: page))
         return dto.toEntity
     }
     
-    func checkInProgress() async throws -> Bool {
+    // MARK: - 추후 수정
+    func checkUserStatus() async throws -> Bool {
         return [true, false].randomElement()!
     }
     
     func reportPhoto(id: Int, content: String) async throws {
         try await requestService.fetchResponse(for: UserRouter.reportPicture(id: id, content: content))
     }
+    
+    // MARK: - 추후 수정
+    func scorePhoto(rate: Int) async throws {}
 }

--- a/Genti_iOS/Genti_iOS/Profile/UseCase/ProfileUseCaseImpl.swift
+++ b/Genti_iOS/Genti_iOS/Profile/UseCase/ProfileUseCaseImpl.swift
@@ -19,13 +19,13 @@ final class ProfileUseCaseImpl: ProfileUseCase {
     }
     
     func fetchInitalUserInfo() async throws -> UserInfoEntity {
-        async let hasInProgressPhoto = userRepository.checkInProgress()
-        async let completedPhotos = userRepository.getMyPictures(page: 0)
+        async let hasInProgressPhoto = userRepository.checkUserStatus()
+        async let completedPhotos = userRepository.fetchPhotos(page: 0)
         return try await .init(hasInProgressPhoto: hasInProgressPhoto, completedImage: completedPhotos)
     }
 
     func getCompletedPhotos(page: Int) async throws -> MyImagesEntitiy {
-        return try await userRepository.getMyPictures(page: page)
+        return try await userRepository.fetchPhotos(page: page)
     }
     
     func load(from urlString: String) async -> UIImage? {

--- a/Genti_iOS/Genti_iOS/Profile/ViewModel/ProfileViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Profile/ViewModel/ProfileViewModel.swift
@@ -37,6 +37,10 @@ final class ProfileViewModel: ViewModel {
         case .viewWillAppear:
             Task {
                 do {
+                    state.page = 0
+                    state.myImages = []
+                    state.isLastPage = false
+                    state.hasInProgressImage = false
                     let entity = try await profileUseCase.fetchInitalUserInfo()
                     state.hasInProgressImage = entity.hasInProgressPhoto
                     state.myImages = entity.completedImage.images

--- a/Genti_iOS/Genti_iOS/Shared/ImageLoaderView.swift
+++ b/Genti_iOS/Genti_iOS/Shared/ImageLoaderView.swift
@@ -14,13 +14,11 @@ struct ImageLoaderView: View {
     var urlString: String
     var resizingMode: ContentMode = .fit
     var ratio: PhotoRatio
-    var width: CGFloat
     
     var body: some View {
         Rectangle()
             .fill(.backgroundWhite)
-            .frame(width: width)
-            .frame(height: width*ratio.ratio)
+            .aspectRatio(1/ratio.ratio, contentMode: .fill)
             .overlay {
                 WebImage(url: URL(string: urlString))
                     .resizable()


### PR DESCRIPTION
## [#49] FIX : 사진신고 오류 해결 및 이미지뷰 리팩터링

## 🌱 작업한 내용
- 사진신고시 content가 항상 ""인상태로 API가 호출되는상황이 발생하였습니다
- 이미지뷰에서 이미지비율에따른 모양을 정의하기위해서 width와 height를 정의해야했고 이를위해 UIScreen.main.bound를 사용했는데 생각해보니 그렇게하지 않고 rectangle의 aspect의 ratio를 사용하고 overlay로 이미지를 올리면 padding만으로 해당설정이가능하다 싶어 그렇게 변경하였습니다

## 🌱 PR Point
### 사진신고시 초기화 문제
```swift
var showAlert: AlertType? = nil {
    didSet {
        self.reportContent = ""
    }
}
```
- 사진신고 content를 viewmodel에서 state로 들고있기때문에 만약에 showAlert가 변할때마다 content를 초기화시켜줌으로써 다시 alert를 호출했을때 기존 값이 유지되지 않게 진행했습니다
- 하지만 iOS의 alert는 확인버튼을 누르면 우선 alert가 dismiss되기때문에 자동으로 reportContent가 ""가 되고 그리고 API가 호출되게됩니다. 결국 해당 didSet이 호출되면서 항상 Content가 ""로 서버에 요청이가게됩니다
- 해당 로직을 파악하고 API호출이 끝나면 string을 빈값으로 변경하였습니다
> [!WARNING]  
> ### alert를 띄울때마다 초기화시켜도 되지않나요?
> 가능은 하고 똑같이 동작하지만 제가 조금 우려했던부분은 이미 서버에 올라간 데이터가 다음 report를 호출할때까지 그대로 메모리에 유지되는부분이었습니다. 확률상 한번 신고를 하면 다시 신고를 하지 않을 가능성이 높기때문에 쓸데없는 메모리를 차지하게된다고 판단했습니다

## 📮 관련 이슈

- Resolved: #49 
