### PR TITLE
[FEAT] 사진생성상태(UserState)에 따른 로직 구현(#55)

### DIFF
--- a/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
+++ b/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
@@ -119,6 +119,9 @@
 		C048A90E2C573A4B00026C80 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = C048A90D2C573A4B00026C80 /* KakaoSDKAuth */; };
 		C048A9102C573A4B00026C80 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = C048A90F2C573A4B00026C80 /* KakaoSDKCommon */; };
 		C048A9122C573A4B00026C80 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = C048A9112C573A4B00026C80 /* KakaoSDKUser */; };
+		C049674D2C5C87FE0097C732 /* TabViewUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C049674C2C5C87FE0097C732 /* TabViewUseCase.swift */; };
+		C049674F2C5C880F0097C732 /* TabViewUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C049674E2C5C880F0097C732 /* TabViewUseCaseImpl.swift */; };
+		C04967512C5C88550097C732 /* TabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04967502C5C88550097C732 /* TabViewModel.swift */; };
 		C088F2C62C25716E00F92320 /* AlbumServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088F2C52C25716E00F92320 /* AlbumServiceImpl.swift */; };
 		C088F2CB2C2572DB00F92320 /* AlbumUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088F2CA2C2572DB00F92320 /* AlbumUseCase.swift */; };
 		C088F2CD2C2572EB00F92320 /* AlbumUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088F2CC2C2572EB00F92320 /* AlbumUseCaseImpl.swift */; };
@@ -179,6 +182,7 @@
 		C0D74A422C1EA68700A45371 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D74A412C1EA68700A45371 /* Router.swift */; };
 		C0D74A442C1EA6A200A45371 /* RoutingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D74A432C1EA6A200A45371 /* RoutingView.swift */; };
 		C0D74A462C1EA6B500A45371 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D74A452C1EA6B500A45371 /* Route.swift */; };
+		C0D942C42C5A48A70044649A /* UserStateDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D942C32C5A48A70044649A /* UserStateDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -311,6 +315,9 @@
 		C048A9032C51B64E00026C80 /* CollectUserInfomationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectUserInfomationViewModel.swift; sourceTree = "<group>"; };
 		C048A9052C51BA1500026C80 /* Int+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Ext.swift"; sourceTree = "<group>"; };
 		C048A9092C5227CF00026C80 /* AuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRouter.swift; sourceTree = "<group>"; };
+		C049674C2C5C87FE0097C732 /* TabViewUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewUseCase.swift; sourceTree = "<group>"; };
+		C049674E2C5C880F0097C732 /* TabViewUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewUseCaseImpl.swift; sourceTree = "<group>"; };
+		C04967502C5C88550097C732 /* TabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewModel.swift; sourceTree = "<group>"; };
 		C088F2C52C25716E00F92320 /* AlbumServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumServiceImpl.swift; sourceTree = "<group>"; };
 		C088F2CA2C2572DB00F92320 /* AlbumUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumUseCase.swift; sourceTree = "<group>"; };
 		C088F2CC2C2572EB00F92320 /* AlbumUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumUseCaseImpl.swift; sourceTree = "<group>"; };
@@ -366,6 +373,7 @@
 		C0D74A412C1EA68700A45371 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		C0D74A432C1EA6A200A45371 /* RoutingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingView.swift; sourceTree = "<group>"; };
 		C0D74A452C1EA6B500A45371 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
+		C0D942C32C5A48A70044649A /* UserStateDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStateDTO.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -814,6 +822,8 @@
 		C017C4702C1C3AA3009924C9 /* Tab */ = {
 			isa = PBXGroup;
 			children = (
+				C049674B2C5C879B0097C732 /* UseCase */,
+				C049674A2C5C878E0097C732 /* ViewModel */,
 				C017C46C2C1C3AA3009924C9 /* Components */,
 				C017C46E2C1C3AA3009924C9 /* Model */,
 				C017C46F2C1C3AA3009924C9 /* GentiTabView.swift */,
@@ -891,6 +901,7 @@
 			isa = PBXGroup;
 			children = (
 				C028435D2C326CAE00B84566 /* UserRouter.swift */,
+				C0D942C32C5A48A70044649A /* UserStateDTO.swift */,
 			);
 			path = User;
 			sourceTree = "<group>";
@@ -983,6 +994,23 @@
 				C0BCC4A72C5883FE009C89C4 /* SocialLoginDTO.swift */,
 			);
 			path = Auth;
+			sourceTree = "<group>";
+		};
+		C049674A2C5C878E0097C732 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				C04967502C5C88550097C732 /* TabViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C049674B2C5C879B0097C732 /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				C049674C2C5C87FE0097C732 /* TabViewUseCase.swift */,
+				C049674E2C5C880F0097C732 /* TabViewUseCaseImpl.swift */,
+			);
+			path = UseCase;
 			sourceTree = "<group>";
 		};
 		C088F2C92C25727F00F92320 /* UseCase */ = {
@@ -1304,6 +1332,7 @@
 				C0D74A422C1EA68700A45371 /* Router.swift in Sources */,
 				C0BCC4A42C58787F009C89C4 /* ReissueTokenDTO.swift in Sources */,
 				C0113D5E2C37C1D700071BF6 /* PhotoDetailViewModel.swift in Sources */,
+				C04967512C5C88550097C732 /* TabViewModel.swift in Sources */,
 				C017C49E2C1C3AA3009924C9 /* GeneratorRequest.swift in Sources */,
 				C017C47C2C1C3AA3009924C9 /* RatingAlertView.swift in Sources */,
 				C017C49C2C1C3AA3009924C9 /* APIService.swift in Sources */,
@@ -1320,6 +1349,7 @@
 				C0113D852C3BEAA400071BF6 /* ShareStyleModifier.swift in Sources */,
 				C017C48A2C1C3AA3009924C9 /* SettingRow.swift in Sources */,
 				C0BCC4B32C58857B009C89C4 /* LoginUseCase.swift in Sources */,
+				C049674F2C5C880F0097C732 /* TabViewUseCaseImpl.swift in Sources */,
 				C017C47F2C1C3AA3009924C9 /* Caution.swift in Sources */,
 				C028437B2C32BF3F00B84566 /* ProfileUseCaseImpl.swift in Sources */,
 				C0113D922C3D426700071BF6 /* UserDefaultsKey.swift in Sources */,
@@ -1400,6 +1430,7 @@
 				C0113D862C3BEAA400071BF6 /* AddXmarkModifier.swift in Sources */,
 				C02843552C314C1E00B84566 /* FeedRouter.swift in Sources */,
 				C0113D902C3D3A0900071BF6 /* OnboardingStep.swift in Sources */,
+				C049674D2C5C87FE0097C732 /* TabViewUseCase.swift in Sources */,
 				C017C4862C1C3AA3009924C9 /* GenerateRequestCompleteView.swift in Sources */,
 				C017C4952C1C3AA3009924C9 /* ImagePickerViewModel.swift in Sources */,
 				C08BB5B32C3E312B00D4CFA9 /* UserDefaultsRepository.swift in Sources */,
@@ -1407,6 +1438,7 @@
 				C08BB5BA2C3E8B3E00D4CFA9 /* LottieView+Ext.swift in Sources */,
 				C02843592C326ACC00B84566 /* PageCommonPictureResponseDTO.swift in Sources */,
 				C08BB5B52C3E313800D4CFA9 /* UserDefaultsRepositoryImpl.swift in Sources */,
+				C0D942C42C5A48A70044649A /* UserStateDTO.swift in Sources */,
 				C0275D832C59EA8A00A68D31 /* SplashViewModel.swift in Sources */,
 				C02843762C32BF0700B84566 /* UserRepositoryImpl.swift in Sources */,
 				C0D74A442C1EA6A200A45371 /* RoutingView.swift in Sources */,

--- a/Genti_iOS/Genti_iOS/App/GentiApp.swift
+++ b/Genti_iOS/Genti_iOS/App/GentiApp.swift
@@ -13,7 +13,6 @@ struct GentiApp: View {
         RoutingView(Router<MainRoute>()) { router in
             SplashView(splashViewModel: SplashViewModel(router: router, splashUseCase: SplashUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl())))
                 .onNotificationRecieved(name: Notification.Name(rawValue: "PushNotificationReceived")) { _ in
-                    router.routeTo(.completeMakeImage)
                     print(#fileID, #function, #line, "- noti received")
                 }
         }

--- a/Genti_iOS/Genti_iOS/App/MainRoute.swift
+++ b/Genti_iOS/Genti_iOS/App/MainRoute.swift
@@ -18,10 +18,11 @@ enum MainRoute: Route {
     case secondGen(data: RequestImageData)
     case thirdGen(data: RequestImageData)
     case requestCompleted
+    case waiting
     case imagePicker(limitCount: Int, viewModel: GetImageFromImagePicker)
     case webView(url: String)
     case photoDetail(image: UIImage)
-    case completeMakeImage
+    case completeMakeImage(imageInfo: CompletePhotoEntity)
     case onboarding
     
     @ViewBuilder
@@ -30,7 +31,7 @@ enum MainRoute: Route {
         case .login:
             LoginView(viewModel: LoginViewModel(loginUseCase: LoginUserCaseImpl(tokenRepository: TokenRepositoryImpl(), loginRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl()), router: router))
         case .mainTab:
-            GentiTabView(router: router)
+            GentiTabView(viewModel: TabViewModel(tabViewUseCase: TabViewUseCaseImpl(userRepository: UserRepositoryImpl(requestService: RequestServiceImpl())), router: router))
         case .setting:
             SettingView(router: router)
         case .photoDetailWithShare(let image):
@@ -43,14 +44,14 @@ enum MainRoute: Route {
             ThirdGeneratorView(viewModel: ThirdGeneratorViewModel(imageGenerateUseCase: ImageGenerateUseCaseImpl(generateRepository: ImageGenerateRepositoryImpl(requsetService: RequestServiceImpl(), imageDataTransferService: ImageDataTransferServiceImpl(), uploadService: UploadServiceImpl())), requestImageData: data, router: router))
         case .imagePicker(limitCount: let limitCount, viewModel: let viewModel):
             PopupImagePickerView(viewModel: ImagePickerViewModel(generatorViewModel: viewModel, router: router, limit: limitCount, albumRepository: AlbumRepositoryImpl(albumService: AlbumServiceImpl())))
-        case .requestCompleted:
+        case .requestCompleted, .waiting:
             GenerateRequestCompleteView(router: router)
         case .webView(url: let url):
             GentiWebView(router: router, urlString: url)
         case .photoDetail(let image):
             PhotoDetailView(viewModel: PhotoDetailViewModel(imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl(), router: router, image: image))
-        case .completeMakeImage:
-            RoutingView(router) { PhotoCompleteView(viewModel: PhotoCompleteViewViewModel(photoInfo: .init(), router: $0, imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl(), userRepository: UserRepositoryImpl(requestService: RequestServiceImpl()))) }
+        case .completeMakeImage(let imageInfo):
+            RoutingView(router) { PhotoCompleteView(viewModel: PhotoCompleteViewViewModel(photoInfo: imageInfo, router: $0, imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl(), userRepository: UserRepositoryImpl(requestService: RequestServiceImpl()))) }
         case .onboarding:
             OnboardingView(viewModel: OnboardingViewModel(router: router))
         case .signIn:
@@ -62,7 +63,7 @@ enum MainRoute: Route {
         switch self {
         case .login, .mainTab, .setting, .secondGen, .thirdGen, .requestCompleted, .webView, .signIn:
             return .push
-        case .photoDetailWithShare, .firstGen, .imagePicker, .photoDetail, .completeMakeImage, .onboarding:
+        case .photoDetailWithShare, .firstGen, .imagePicker, .photoDetail, .completeMakeImage, .onboarding, .waiting:
             return .fullScreenCover
         }
     }

--- a/Genti_iOS/Genti_iOS/App/SceneDelegate.swift
+++ b/Genti_iOS/Genti_iOS/App/SceneDelegate.swift
@@ -13,7 +13,7 @@ import KakaoSDKAuth
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    
+    var userdefultRepository = UserDefaultsRepositoryImpl()
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
             if (AuthApi.isKakaoTalkLoginUrl(url)) {
@@ -31,9 +31,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window?.makeKeyAndVisible()
         
         
-        guard let _ = connectionOptions.notificationResponse else { return }
-        // 만약에 앱이 꺼진상태에서 push notification받았을 때
-        
+        if let response = connectionOptions.notificationResponse {
+            if response.notification.request.content.body == "test" {
+                userdefultRepository.set(to: true, forKey: .showImage)
+            }
+        }
         return
         
     }

--- a/Genti_iOS/Genti_iOS/CollectUserInfomation/CollectUserInfomationView.swift
+++ b/Genti_iOS/Genti_iOS/CollectUserInfomation/CollectUserInfomationView.swift
@@ -25,6 +25,7 @@ struct CollectUserInfomationView: View {
             backgroundView()
         )
         .toolbar(.hidden, for: .navigationBar)
+        .customAlert(alertType: $viewModel.state.showAlert)
     }
     
     func headerView() -> some View {

--- a/Genti_iOS/Genti_iOS/CollectUserInfomation/CollectUserInfomationView.swift
+++ b/Genti_iOS/Genti_iOS/CollectUserInfomation/CollectUserInfomationView.swift
@@ -24,6 +24,11 @@ struct CollectUserInfomationView: View {
         .background(
             backgroundView()
         )
+        .overlay(alignment: .center) {
+            if viewModel.state.isLoading {
+                LoadingView()
+            }
+        }
         .toolbar(.hidden, for: .navigationBar)
         .customAlert(alertType: $viewModel.state.showAlert)
     }

--- a/Genti_iOS/Genti_iOS/Complete/Model/CompletePhotoEntity.swift
+++ b/Genti_iOS/Genti_iOS/Complete/Model/CompletePhotoEntity.swift
@@ -8,7 +8,22 @@
 import Foundation
 
 struct CompletePhotoEntity {
-    var id: Int = 1
-    var imageUrlString: String = "https://d2rvmd5lmgmzuf.cloudfront.net/ADMIN_UPLOADED_IMAGE/어드민응답1.png-f8614bc9-3614-40bb-a91e-f8398be66d7c"
-    var imageRatio: PhotoRatio = .twoThird
+    var requestId: Int
+    var responseId: Int
+    var imageUrlString: String
+    var imageRatio: PhotoRatio
+    
+    init(requestId: Int, photoInfo: UserStateDTO.PictureGenerateResponse) {
+        self.requestId = requestId
+        self.responseId = photoInfo.pictureGenerateResponseId
+        self.imageUrlString = photoInfo.pictureCompleted.url
+        self.imageRatio = photoInfo.pictureCompleted.pictureRatio == "RATIO_3_2" ? .threeSecond : .twoThird
+    }
+    
+    init() {
+        self.requestId = 1
+        self.responseId = 2
+        self.imageUrlString = "https://d2rvmd5lmgmzuf.cloudfront.net/ADMIN_UPLOADED_IMAGE/어드민응답1.png-f8614bc9-3614-40bb-a91e-f8398be66d7c"
+        self.imageRatio = .twoThird
+    }
 }

--- a/Genti_iOS/Genti_iOS/Complete/PhotoCompleteView.swift
+++ b/Genti_iOS/Genti_iOS/Complete/PhotoCompleteView.swift
@@ -66,7 +66,7 @@ struct PhotoCompleteView: View {
                 }
             }
         }
-        .addCustomPopup(isPresented: $viewModel.state.showRatingView, popupType: .rating)
+        .addCustomPopup(isPresented: $viewModel.state.showRatingView, popupType: .rating(viewModel.photoInfo))
         .onReceive(NotificationCenter.default.publisher(for: .init("ratingCompleted"))) { _ in
             self.viewModel.sendAction(.ratingActionIsDone)
         }

--- a/Genti_iOS/Genti_iOS/Complete/ViewModel/PhotoCompleteViewViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Complete/ViewModel/PhotoCompleteViewViewModel.swift
@@ -116,16 +116,15 @@ final class PhotoCompleteViewViewModel: ViewModel {
             try await userRepository.reportPhoto(responseId: self.photoInfo.responseId, content: self.state.reportContent)
             state.reportContent = ""
             state.isLoading = false
-            state.showAlert = .reportComplete
+            state.showAlert = .reportComplete(action: { self.router.dismissSheet() })
         } catch(let error) {
             state.reportContent = ""
+            state.isLoading = false
             guard let error = error as? GentiError else {
-                state.isLoading = false
-                state.showAlert = .reportUnknownedError(error: error, action: nil)
+                state.showAlert = .reportUnknownedError(error: error, action: { self.router.dismissSheet() })
                 return
             }
-            state.isLoading = false
-            state.showAlert = .reportGentiError(error: error, action: nil)
+            state.showAlert = .reportGentiError(error: error, action: { self.router.dismissSheet() })
         }
     }
 

--- a/Genti_iOS/Genti_iOS/Generator/ThirdGeneratorView.swift
+++ b/Genti_iOS/Genti_iOS/Generator/ThirdGeneratorView.swift
@@ -27,6 +27,7 @@ struct ThirdGeneratorView: View {
                 }
             } //:ZSTACK
             .toolbar(.hidden, for: .navigationBar)
+            .customAlert(alertType: $viewModel.state.showAlert)
     }
     
     private func completeButtonView() -> some View {

--- a/Genti_iOS/Genti_iOS/Home/MainFeedView.swift
+++ b/Genti_iOS/Genti_iOS/Home/MainFeedView.swift
@@ -40,6 +40,7 @@ struct MainFeedView: View {
         .onFirstAppear {
             self.viewModel.sendAction(.viewWillAppear)
         }
+        .customAlert(alertType: $viewModel.state.showAlert)
     }
     
     private func feedsView() -> some View {

--- a/Genti_iOS/Genti_iOS/Home/Model/UserDefaultsKey.swift
+++ b/Genti_iOS/Genti_iOS/Home/Model/UserDefaultsKey.swift
@@ -13,6 +13,7 @@ enum UserDefaultsKey: String {
     case accessToken
     case refreshToken
     case userRole
+    case showImage
 }
 
 

--- a/Genti_iOS/Genti_iOS/Login/LoginView.swift
+++ b/Genti_iOS/Genti_iOS/Login/LoginView.swift
@@ -28,7 +28,13 @@ struct LoginView: View {
         .background {
             backgroundView()
         }
+        .overlay(alignment: .center) {
+            if viewModel.state.isLoading {
+                LoadingView()
+            }
+        }
         .toolbar(.hidden, for: .navigationBar)
+        .customAlert(alertType: $viewModel.state.showAlert)
     }
     
     private func socialLoginButtonsView() -> some View {

--- a/Genti_iOS/Genti_iOS/Network/User/UserRouter.swift
+++ b/Genti_iOS/Genti_iOS/Network/User/UserRouter.swift
@@ -9,26 +9,35 @@ import Foundation
 
 import Alamofire
 
+enum UserState {
+    case inProgress
+    case canMake
+    case awaitUserVerification(CompletePhotoEntity)
+    case canceled(requestId: Int)
+    case error
+}
+
 enum UserRouter: URLRequestConvertible {
     
     case fetchMyPictures(page: Int)
-    case reportPicture(id: Int, content: String)
-    case ratePicture(id: Int, rate: Int)
+    case reportPicture(responseId: Int, content: String)
+    case ratePicture(responseId: Int, rate: Int)
+    case getUserState
+    case checkCompletedImage(responeId: Int)
+    case checkCanceledImage(requestId: Int)
     
     var method: HTTPMethod {
         switch self {
-        case .fetchMyPictures:
+        case .fetchMyPictures, .getUserState, .checkCanceledImage:
             return .get
-        case .reportPicture:
-            return .post
-        case .ratePicture:
+        case .reportPicture, .ratePicture, .checkCompletedImage:
             return .post
         }
     }
     
     var headers: HTTPHeaders {
         switch self {
-        case .fetchMyPictures, .reportPicture, .ratePicture:
+        case .fetchMyPictures, .reportPicture, .ratePicture, .getUserState, .checkCompletedImage, .checkCanceledImage:
             return []
         }
     }
@@ -44,8 +53,14 @@ enum UserRouter: URLRequestConvertible {
             return "/api/v1/users/pictures/my"
         case .reportPicture:
             return "/api/v1/users/reports"
-        case .ratePicture(let id, _):
-            return "/api/v1/users/picture-generate-responses/\(id)/rate"
+        case .ratePicture(let responseId, _):
+            return "/api/v1/users/picture-generate-responses/\(responseId)/rate"
+        case .getUserState:
+            return "/api/v1/users/picture-generate-requests/pending"
+        case .checkCompletedImage(let responseId):
+            return "/api/v1/users/picture-generate-responses/\(responseId)/verify"
+        case .checkCanceledImage(let requestId):
+            return "/api/v1/users/picture-generate-requests/\(requestId)/confirm-cancel-status"
         }
     }
     
@@ -64,18 +79,19 @@ enum UserRouter: URLRequestConvertible {
             parameters["sortBy"] = "createdAt"
             parameters["direction"] = "desc"
             urlRequest = try URLEncoding(destination: .queryString).encode(urlRequest, with: parameters)
-        case .reportPicture(id: let id, content: let content):
+        case .reportPicture(let responseId, content: let content):
             var parameters: [String: Any] = [:]
-            parameters["pictureGenerateResponseId"] = id
+            parameters["pictureGenerateResponseId"] = responseId
             parameters["content"] = content
             urlRequest.httpBody = try JSONSerialization.data(withJSONObject: parameters)
             
         case .ratePicture(_, let rate):
-             var parameters: [String: Any] = [:]
-             parameters["star"] = rate
-             urlRequest = try URLEncoding(destination: .queryString).encode(urlRequest, with: parameters)
-         }
-        
+            var parameters: [String: Any] = [:]
+            parameters["star"] = rate
+            urlRequest = try URLEncoding(destination: .queryString).encode(urlRequest, with: parameters)
+        case .getUserState, .checkCompletedImage, .checkCanceledImage:
+            return urlRequest
+        }
         return urlRequest
     }
     

--- a/Genti_iOS/Genti_iOS/Network/User/UserStateDTO.swift
+++ b/Genti_iOS/Genti_iOS/Network/User/UserStateDTO.swift
@@ -1,0 +1,26 @@
+//
+//  UserStateDTO.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 7/31/24.
+//
+
+import Foundation
+
+struct UserStateDTO: Codable {
+    let pictureGenerateRequestId: Int?
+    let status: String
+    let pictureGenerateResponse: PictureGenerateResponse?
+    
+    struct PictureGenerateResponse: Codable {
+        let pictureGenerateResponseId: Int
+        let pictureCompleted: PictureCompleted
+
+    }
+    
+    struct PictureCompleted: Codable {
+        let id: Int
+        let url: String
+        let key, pictureRatio, type: String
+    }
+}

--- a/Genti_iOS/Genti_iOS/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
+++ b/Genti_iOS/Genti_iOS/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
@@ -23,7 +23,7 @@ final class PhotoDetailViewModel: ViewModel {
         case downloadButtonTap
         case xmarkTap
     }
-
+    
     var state: State
     
     init(imageRepository: ImageRepository, hapticRepository: HapticRepository, router: Router<MainRoute>, image: UIImage) {
@@ -36,14 +36,17 @@ final class PhotoDetailViewModel: ViewModel {
     func sendAction(_ input: Input) {
         switch input {
         case .downloadButtonTap:
-            Task {
-                do {
-                    let writeSuccess = await imageRepository.writeToPhotoAlbum(image: state.image)
-                    hapticRepository.notification(type: writeSuccess ? .success : .error)
-                }
-            }
+            Task { await download() }
         case .xmarkTap:
             router.dismissSheet()
+        }
+    }
+    
+    @MainActor
+    func download() async {
+        do {
+            let writeSuccess = await imageRepository.writeToPhotoAlbum(image: state.image)
+            hapticRepository.notification(type: writeSuccess ? .success : .error)
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/PopUp/Model/PopUpType.swift
+++ b/Genti_iOS/Genti_iOS/PopUp/Model/PopUpType.swift
@@ -10,14 +10,14 @@ import Foundation
 /// PopupType 열거형은 다양한 팝업 타입을 정의하고, 각 타입에 맞는 팝업 객체를 생성합니다.
 enum PopupType {
     case selectOnboarding
-    case rating
+    case rating(CompletePhotoEntity)
 
     var object: any CustomPopup {
         switch self {
         case .selectOnboarding:
             return SelectOnboardingPopup()
-        case .rating:
-            return RatingPopup()
+        case .rating(let photoInfo):
+            return RatingPopup(photoInfo: photoInfo)
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/PopUp/Model/RatingPopup.swift
+++ b/Genti_iOS/Genti_iOS/PopUp/Model/RatingPopup.swift
@@ -10,9 +10,15 @@ import SwiftUI
 import PopupView
 
 struct RatingPopup: CustomPopup {
+    
+    let photoInfo: CompletePhotoEntity
+    
+    init(photoInfo: CompletePhotoEntity) {
+        self.photoInfo = photoInfo
+    }
 
     var contentView: some View {
-        RatingAlertView(viewModel: RatingAlertViewModel(userRepository: UserRepositoryImpl(requestService: RequestServiceImpl())))
+        RatingAlertView(viewModel: RatingAlertViewModel(userRepository: UserRepositoryImpl(requestService: RequestServiceImpl()), photoInfo: photoInfo))
     }
 
     var customize: (Popup<AnyView>.PopupParameters) -> Popup<AnyView>.PopupParameters {

--- a/Genti_iOS/Genti_iOS/PopUp/ViewModel/RatingAlertViewModel.swift
+++ b/Genti_iOS/Genti_iOS/PopUp/ViewModel/RatingAlertViewModel.swift
@@ -24,9 +24,11 @@ final class RatingAlertViewModel: ViewModel {
     }
     
     var state: State
-    
-    init(userRepository: UserRepository) {
+    var photoInfo: CompletePhotoEntity
+
+    init(userRepository: UserRepository, photoInfo: CompletePhotoEntity) {
         self.userRepository = userRepository
+        self.photoInfo = photoInfo
         self.state = .init()
     }
     
@@ -43,13 +45,15 @@ final class RatingAlertViewModel: ViewModel {
     
     @MainActor
     func submitRating() async {
+        defer {
+            state.isLoading = false
+            NotificationCenter.default.post(name: Notification.Name(rawValue: "ratingCompleted"), object: nil)
+        }
         do {
             self.state.isLoading = true
-            try await userRepository.scorePhoto(rate: state.rating)
-            self.state.isLoading = false
-            NotificationCenter.default.post(name: Notification.Name(rawValue: "ratingCompleted"), object: nil)
-        } catch {
-            
+            try await userRepository.scorePhoto(responseId: photoInfo.responseId, rate: state.rating)
+        } catch(let error) {
+            print(error)
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Profile/ProfileView.swift
+++ b/Genti_iOS/Genti_iOS/Profile/ProfileView.swift
@@ -116,10 +116,16 @@ struct ProfileView: View {
             }
 
         }
+        .overlay(alignment: .center) {
+            if viewModel.state.isLoading {
+                LoadingView()
+            }
+        }
         .toolbar(.hidden, for: .navigationBar)
         .onFirstAppear {
             viewModel.sendAction(.viewWillAppear)
         }
+        .customAlert(alertType: $viewModel.state.showAlert)
         .refreshable {
             print(#fileID, #function, #line, "- refresh profile")
         }

--- a/Genti_iOS/Genti_iOS/Profile/Repository/UserRepository.swift
+++ b/Genti_iOS/Genti_iOS/Profile/Repository/UserRepository.swift
@@ -9,7 +9,10 @@ import Foundation
 
 protocol UserRepository {
     func fetchPhotos(page: Int) async throws -> MyImagesEntitiy
-    func checkUserStatus() async throws -> Bool
-    func reportPhoto(id: Int, content: String) async throws
-    func scorePhoto(rate: Int) async throws
+    func checkUserInProgress() async throws -> Bool
+    func reportPhoto(responseId: Int, content: String) async throws
+    func scorePhoto(responseId: Int, rate: Int) async throws
+    func getUserState() async throws -> UserState
+    func checkCompletedImage(responeId: Int) async throws
+    func checkCanceledImage(requestId: Int) async throws
 }

--- a/Genti_iOS/Genti_iOS/Profile/UseCase/ProfileUseCaseImpl.swift
+++ b/Genti_iOS/Genti_iOS/Profile/UseCase/ProfileUseCaseImpl.swift
@@ -19,7 +19,7 @@ final class ProfileUseCaseImpl: ProfileUseCase {
     }
     
     func fetchInitalUserInfo() async throws -> UserInfoEntity {
-        async let hasInProgressPhoto = userRepository.checkUserStatus()
+        async let hasInProgressPhoto = userRepository.checkUserInProgress()
         async let completedPhotos = userRepository.fetchPhotos(page: 0)
         return try await .init(hasInProgressPhoto: hasInProgressPhoto, completedImage: completedPhotos)
     }

--- a/Genti_iOS/Genti_iOS/Shared/Alert/AlertType.swift
+++ b/Genti_iOS/Genti_iOS/Shared/Alert/AlertType.swift
@@ -12,7 +12,7 @@ enum AlertType {
     typealias AlertAction = (()->Void)
     
     case report(action: AlertAction, placeholder: String, text: Binding<String>)
-    case reportComplete
+    case reportComplete(action: AlertAction)
     case logout(action: AlertAction)
     case resign(action: AlertAction)
     case reportUnknownedError(error: Error, action: AlertAction?)
@@ -26,10 +26,10 @@ enum AlertType {
                          actions: [.init(title: "취소", style: .cancel),.init(title: "제출하기", action: action)],
                          textFieldPlaceholder: placeholder,
                          textFieldText: text)
-        case .reportComplete:
+        case .reportComplete(let action):
             return .init(title: "의견 감사합니다!",
                          message: "작성해주신 내용 잘 확인하여 더 좋은\n서비스를 제공하는 젠티가 되겠습니다",
-                         actions: [.init(title: "확인했습니다")])
+                         actions: [.init(title: "확인했습니다", action: action)])
         case .logout(let action):
             return .init(title: "정말 로그아웃 하시겠어요?",
                          message: "사진 생성중에 로그아웃 하시면\n오류가 발생할 수 있습니다. 주의해주세요!",

--- a/Genti_iOS/Genti_iOS/Shared/Alert/AlertType.swift
+++ b/Genti_iOS/Genti_iOS/Shared/Alert/AlertType.swift
@@ -15,6 +15,8 @@ enum AlertType {
     case reportComplete
     case logout(action: AlertAction)
     case resign(action: AlertAction)
+    case reportUnknownedError(error: Error, action: AlertAction?)
+    case reportGentiError(error: GentiError, action: AlertAction?)
     
     var data: Alert {
         switch self {
@@ -36,6 +38,13 @@ enum AlertType {
             return .init(title: "정말 탈퇴 하시겠어요?",
                          message: "생성한 사진 내역이 모두 사라집니다.\n주의해주세요!",
                          actions: [.init(title: "취소하기", style: .cancel), .init(title: "탈퇴하기", action: action)])
+        case .reportUnknownedError(let error, let action):
+            return .init(title: "알수없는문제", message: error.localizedDescription, actions: [.init(title: "확인", action: action)])
+        case .reportGentiError(let error, let action):
+            guard let title = error.code, let message = error.message else {
+                return .init(title: "비어있음", message: "비어있음", actions: [.init(title: "확인", action: action)])
+            }
+            return .init(title: title, message: message, actions: [.init(title: "확인", action: action)])
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Tab/Components/CustomTabView.swift
+++ b/Genti_iOS/Genti_iOS/Tab/Components/CustomTabView.swift
@@ -8,18 +8,19 @@
 import SwiftUI
 
 struct CustomTabView: View {
-    @Bindable var router: Router<MainRoute>
-    @Binding var currentTab: Tab
+
+    @Binding var viewModel: TabViewModel
+    
     var body: some View {
         HStack(alignment: .center) {
-            Image(currentTab == .feed ? "Feed_fill" : "Feed_empty")
+            Image(viewModel.state.currentTab == .feed ? "Feed_fill" : "Feed_empty")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 26, height: 26)
                 .padding(3)
                 .background(.black.opacity(0.001))
                 .onTapGesture {
-                    currentTab = .feed
+                    viewModel.sendAction(.feedIconTap)
                 }
             Spacer()
             
@@ -28,19 +29,19 @@ struct CustomTabView: View {
                 .padding(3)
                 .background(.black.opacity(0.001))
                 .onTapGesture {
-                    router.routeTo(.firstGen)
+                    viewModel.sendAction(.cameraIconTap)
                 }
 
 
             Spacer()
-            Image(currentTab == .profile ? "User_fill" : "User_empty")
+            Image(viewModel.state.currentTab == .profile ? "User_fill" : "User_empty")
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 26, height: 26)
                 .padding(3)
                 .background(.black.opacity(0.001))
                 .onTapGesture {
-                    currentTab = .profile
+                    viewModel.sendAction(.profileIconTap)
                 }
         }
         .frame(height: 50)
@@ -59,23 +60,3 @@ struct CustomTabView: View {
         .shadow(type: .strong)
     }
 }
-
-fileprivate struct CustomTabViewPreView: View {
-    @State private var selected: Tab = .feed
-    var body: some View {
-        CustomTabView(router: .init(), currentTab: $selected)
-    }
-}
-
-
-#Preview {
-    ZStack(alignment: .bottom) {
-        // Background Color
-        Color.black
-            .ignoresSafeArea()
-        // Content
-        CustomTabViewPreView()
-    } //:ZSTACK
-}
-
-

--- a/Genti_iOS/Genti_iOS/Tab/GentiTabView.swift
+++ b/Genti_iOS/Genti_iOS/Tab/GentiTabView.swift
@@ -26,6 +26,12 @@ struct GentiTabView: View {
             
             CustomTabView(viewModel: $viewModel)
         } //: ZSTACK
+        .overlay(alignment: .center) {
+            if viewModel.state.isLoading {
+                LoadingView()
+            }
+        }
+        .customAlert(alertType: $viewModel.state.showAlert)
         .ignoresSafeArea(.keyboard)
         .toolbar(.hidden, for: .navigationBar)
     }

--- a/Genti_iOS/Genti_iOS/Tab/GentiTabView.swift
+++ b/Genti_iOS/Genti_iOS/Tab/GentiTabView.swift
@@ -8,26 +8,29 @@
 import SwiftUI
 
 struct GentiTabView: View {
-    @State var currentTab: Tab = .feed
-    @Bindable var router: Router<MainRoute>
+    @State var viewModel: TabViewModel
+    
+    init(viewModel: TabViewModel) {
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         ZStack(alignment: .bottom) {
-            TabView(selection: $currentTab) {
-                MainFeedView(viewModel: MainFeedViewModel(feedRepository: FeedRepositoryImpl(requestService: RequestServiceImpl()), userDefaultsRepository: UserDefaultsRepositoryImpl(), router: router))
+            TabView(selection: $viewModel.state.currentTab) {
+                MainFeedView(viewModel: MainFeedViewModel(feedRepository: FeedRepositoryImpl(requestService: RequestServiceImpl()), userDefaultsRepository: UserDefaultsRepositoryImpl(), router: viewModel.router))
                     .tag(Tab.feed)
 
-                ProfileView(viewModel: ProfileViewModel(profileUseCase: ProfileUseCaseImpl(imageRepository: ImageRepositoryImpl(), userRepository: UserRepositoryImpl(requestService: RequestServiceImpl())), router: router))
+                ProfileView(viewModel: ProfileViewModel(profileUseCase: ProfileUseCaseImpl(imageRepository: ImageRepositoryImpl(), userRepository: UserRepositoryImpl(requestService: RequestServiceImpl())), router: viewModel.router))
                 .tag(Tab.profile)
             }
             
-            CustomTabView(router: router, currentTab: $currentTab)
+            CustomTabView(viewModel: $viewModel)
         } //: ZSTACK
         .ignoresSafeArea(.keyboard)
         .toolbar(.hidden, for: .navigationBar)
     }
 }
 
-#Preview {
-    GentiTabView(router: .init())
-}
+//#Preview {
+//    GentiTabView(router: .init())
+//}

--- a/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCase.swift
+++ b/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  TabViewUseCase.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/2/24.
+//
+
+import Foundation
+
+protocol TabViewUseCase {
+    func getUserState() async throws -> UserState
+    func checkCanceledImage(requestId: Int) async throws
+}

--- a/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCaseImpl.swift
+++ b/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCaseImpl.swift
@@ -1,0 +1,25 @@
+//
+//  TabViewUseCaseImpl.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/2/24.
+//
+
+import Foundation
+
+final class TabViewUseCaseImpl: TabViewUseCase {
+    
+    let userRepository: UserRepository
+    
+    init(userRepository: UserRepository) {
+        self.userRepository = userRepository
+    }
+    
+    func getUserState() async throws -> UserState {
+        return try await userRepository.getUserState()
+    }
+    
+    func checkCanceledImage(requestId: Int) async throws {
+        try await userRepository.checkCanceledImage(requestId: requestId)
+    }
+}

--- a/Genti_iOS/Genti_iOS/Tab/ViewModel/TabViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Tab/ViewModel/TabViewModel.swift
@@ -1,0 +1,64 @@
+//
+//  TabViewModel.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/2/24.
+//
+
+import Foundation
+
+@Observable
+final class TabViewModel: ViewModel {
+    
+    var tabViewUseCase: TabViewUseCase
+    var router: Router<MainRoute>
+    
+    var state: State
+    struct State {
+        var currentTab: Tab = .feed
+        
+    }
+    enum Input {
+        case feedIconTap
+        case profileIconTap
+        case cameraIconTap
+    }
+    func sendAction(_ input: Input) {
+        switch input {
+        case .feedIconTap:
+            state.currentTab = .feed
+        case .profileIconTap:
+            state.currentTab = .profile
+        case .cameraIconTap:
+            Task {
+                switch try await tabViewUseCase.getUserState() {
+                case .inProgress:
+                    router.routeTo(.waiting)
+                case .canMake:
+                    router.routeTo(.firstGen)
+                case .awaitUserVerification(let completePhotoEntity):
+                    router.routeTo(.completeMakeImage(imageInfo: completePhotoEntity))
+                case .canceled(let requestId):
+                    // MARK: - 취소되었을떄
+                    Task {
+                        do {
+                            try await tabViewUseCase.checkCanceledImage(requestId: requestId)
+                        } catch(let error) {
+                            print(error)
+                        }
+                    }
+                    router.routeTo(.firstGen)
+                case .error:
+                    print(#fileID, #function, #line, "- 에러발생")
+                }
+            }
+        }
+    }
+    
+    init(tabViewUseCase: TabViewUseCase, router: Router<MainRoute>) {
+        self.tabViewUseCase = tabViewUseCase
+        self.router = router
+        self.state = .init()
+    }
+    
+}


### PR DESCRIPTION
## [#55] FEAT : 사진생성상태(UserState)에 따른 로직 구현

## 🌱 작업한 내용
- 기획적으로 유저는 사진생성을 1개만 할수있습니다. 이 의미는 사진생성중인 경우 새로운 사진생성요청을 보낼수없다는걸 의미합니다. 따라서 지금유저가 사진생성중인지에 따라서 탭바의 카메라버튼을 눌렀을때(사진생성을 위한 action) 분기처리가필요합니다.
- 또한 유저가 사진을 확인헀는지 안했는지는 비동기적인 action이므로 해당 action의 시점을 서버에 알려주는 작업이 필요합니다

## 🌱 PR Point
### 유저상태(UserStatus)에 따른 router분기
- swagger상으로 userstatus는 총 4가지가 존재합니다
> [!NOTE]  
>IN_PROGRESS : 작업이 진행 중
>AWAIT_USER_VERIFICATION : 완료되었고, 사용자가 확인한 적이 없어 확인을 필요로 함
>CANCELED : 1.공급자가 주문을 받아놓고 회원탈퇴한경우 2.12시간동안 주문을 아무도 받지 않을 경우, 3. 공급자가 주문을 받고 노쇼한 경우 취소되어 FE 분기처리
>NEW_REQUEST_AVAILABLE : 이전 주문이 완료되었거나 주문한적이 없는 등 새로운 요청 생성이 가능한 상태이다.

- 카메라버튼을 눌렀을때 유저의 상태가 IN_PROGRESS라면 대기하라는 뷰를 보여줘야하고
- 카메라버튼을 눌렀을때 유저의 상태가 AWAIT_USER_VERIFICATION이라면 완성된 사진을 보여줘야하고
- 카메라버튼을 눌렀을때 유저의 상태가 CANCELED라면 알림으로 알려주고 사진생성뷰로 넘어가게해주고
- 카메라버튼을 눌렀을때 유저의 상태가 NEW_REQUERT_AVAILABLE이라면 사진생성뷰로 넘어가게해줘야합니다

### 유저상태(UserStatus)변경 API호출
- 예를들어 두번째 경우인 유저상태가 AWAIT_USER_VERIFICATION이라면 다시 유저의 상태를 변경해줘야합니다
- 기획상 별점 팝업 및 신고 알림을 띄우고 확인버튼을 누르면 사진생성완료뷰가 닫히게됩니다 따라서 이때도 확인API를 쏴줘야합니다

#### 1. 별점팝업 확인버튼
- 별점확인버튼을 누르면 별점API를 쏘고 연쇄적으로 확인 API를 호출하고 사진완료뷰를 닫습니다
- 이때 유저의 상태가 NEW_REQUERT_AVAILABLE상태로 바뀌게되어 사진생성이 가능한 상태로 바뀝니다

#### 2. 신고알림 확인버튼
- 신고를 하면 신고 API를 쏘고 연쇄적으로 확인API를 호출하고 알림창과 사진완료뷰를 닫습니다
- 이때 유저의 상태가 NEW_REQUERT_AVAILABLE상태로 바뀌게되어 사진생성이 가능한 상태로 바뀝니다

## 📮 관련 이슈

- Resolved: #55 
