### PR TITLE
[FEAT] 사진생성실패시 재생성flow로직 추가(#65)

### DIFF
--- a/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
+++ b/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
@@ -1663,7 +1663,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z225784MRD;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1699,7 +1699,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = Z225784MRD;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCase.swift
+++ b/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCase.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol TabViewUseCase {
     func getUserState() async throws -> UserState
     func checkCanceledImage(requestId: Int) async throws
+    func hasCanceledCase() async throws -> (Bool, Int?)
 }

--- a/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCaseImpl.swift
+++ b/Genti_iOS/Genti_iOS/Tab/UseCase/TabViewUseCaseImpl.swift
@@ -22,4 +22,14 @@ final class TabViewUseCaseImpl: TabViewUseCase {
     func checkCanceledImage(requestId: Int) async throws {
         try await userRepository.checkCanceledImage(requestId: requestId)
     }
+    
+    func hasCanceledCase() async throws -> (Bool, Int?) {
+        let userState = try await userRepository.getUserState()
+        switch userState {
+        case .canceled(let requestId):
+            return (true, requestId)
+        default:
+            return (false, nil)
+        }
+    }
 }


### PR DESCRIPTION
## [#65] FEAT : 사진생성실패시 재생성flow로직 추가

## 🌱 작업한 내용
- 유저가 사진 생성에 실패했을시 앱에 진입시 메인뷰에서 "사진생성에실패했다는알림"을 띄워주고 이후에 사진을 재생성할수있도록합니다

## 🌱 PR Point
### 기존에있는 UserState를 가져오는 repository를 재활용
```swift
func hasCanceledCase() async throws -> (Bool, Int?) {
    let userState = try await userRepository.getUserState()
    switch userState {
    case .canceled(let requestId):
        return (true, requestId)
    default:
        return (false, nil)
    }
}
```
- 유저스테이트레포지토리에서 받아온 모든 case를 usecase에서 변환후 (취소된사진이있는지여부, requestID)를 tuple로 넘겨줍니다

```swift
@MainActor
func handleCanceledCase() async {
    do {
        let cancelCase = try await tabViewUseCase.hasCanceledCase()
        if cancelCase.0 {
            guard let requestId = cancelCase.1 else { return }
            await handleCanceledState(requestId: requestId)
        }
    } catch(let error) {
        state.isLoading = false
        guard let error = error as? GentiError else {
            state.showAlert = .reportUnknownedError(error: error, action: nil)
            return
        }
        state.showAlert = .reportGentiError(error: error, action: nil)
    }
}
```
- 취소된 요청이 있는경우 알림을 띄워주고 확인을 누르면 사진생성뷰로 넘어가는 로직을 재사용합니다

## 📮 관련 이슈

- Resolved: #65 
