### PR TITLE
[FEAT] Amplitude추가(#75)

### DIFF
--- a/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
+++ b/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		C0DE62722C6C61C0005937B0 /* DetailViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE62712C6C61C0005937B0 /* DetailViewType.swift */; };
 		C0DE62752C6C631C005937B0 /* LogEventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE62742C6C631C005937B0 /* LogEventType.swift */; };
 		C0DE62772C6C6338005937B0 /* LogUserPropertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE62762C6C6338005937B0 /* LogUserPropertyType.swift */; };
+		C0DE62792C6C882D005937B0 /* PageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE62782C6C882D005937B0 /* PageType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -383,6 +384,7 @@
 		C0DE62712C6C61C0005937B0 /* DetailViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewType.swift; sourceTree = "<group>"; };
 		C0DE62742C6C631C005937B0 /* LogEventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventType.swift; sourceTree = "<group>"; };
 		C0DE62762C6C6338005937B0 /* LogUserPropertyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogUserPropertyType.swift; sourceTree = "<group>"; };
+		C0DE62782C6C882D005937B0 /* PageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1182,6 +1184,7 @@
 			children = (
 				C0DE62742C6C631C005937B0 /* LogEventType.swift */,
 				C0DE62762C6C6338005937B0 /* LogUserPropertyType.swift */,
+				C0DE62782C6C882D005937B0 /* PageType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1501,6 +1504,7 @@
 				C017C4202C1C3A62009924C9 /* GentiApp.swift in Sources */,
 				C0BCC4AD2C58842C009C89C4 /* SocialLoginEntity.swift in Sources */,
 				C017C4912C1C3AA3009924C9 /* SettingView.swift in Sources */,
+				C0DE62792C6C882D005937B0 /* PageType.swift in Sources */,
 				C088F2E02C26F0EA00F92320 /* ImageGenerateRepository.swift in Sources */,
 				C0BCC4AF2C58843E009C89C4 /* GentiSocialLoginType.swift in Sources */,
 				C02843572C314E7200B84566 /* ExampleWithPictureFindResponseDTO.swift in Sources */,

--- a/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
+++ b/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
@@ -184,6 +184,10 @@
 		C0D74A462C1EA6B500A45371 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D74A452C1EA6B500A45371 /* Route.swift */; };
 		C0D942C42C5A48A70044649A /* UserStateDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D942C32C5A48A70044649A /* UserStateDTO.swift */; };
 		C0DE626D2C6C33CB005937B0 /* Amplitude in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE626C2C6C33CB005937B0 /* Amplitude */; };
+		C0DE62702C6C4576005937B0 /* EventLogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE626F2C6C4575005937B0 /* EventLogManager.swift */; };
+		C0DE62722C6C61C0005937B0 /* DetailViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE62712C6C61C0005937B0 /* DetailViewType.swift */; };
+		C0DE62752C6C631C005937B0 /* LogEventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE62742C6C631C005937B0 /* LogEventType.swift */; };
+		C0DE62772C6C6338005937B0 /* LogUserPropertyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE62762C6C6338005937B0 /* LogUserPropertyType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -375,6 +379,10 @@
 		C0D74A432C1EA6A200A45371 /* RoutingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingView.swift; sourceTree = "<group>"; };
 		C0D74A452C1EA6B500A45371 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		C0D942C32C5A48A70044649A /* UserStateDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStateDTO.swift; sourceTree = "<group>"; };
+		C0DE626F2C6C4575005937B0 /* EventLogManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLogManager.swift; sourceTree = "<group>"; };
+		C0DE62712C6C61C0005937B0 /* DetailViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewType.swift; sourceTree = "<group>"; };
+		C0DE62742C6C631C005937B0 /* LogEventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventType.swift; sourceTree = "<group>"; };
+		C0DE62762C6C6338005937B0 /* LogUserPropertyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogUserPropertyType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -827,6 +835,7 @@
 		C04967B62C6491FC0097C732 /* Instructure */ = {
 			isa = PBXGroup;
 			children = (
+				C0DE626E2C6C4562005937B0 /* EventLog */,
 				C017C45C2C1C3AA3009924C9 /* Constants.swift */,
 				C04967B82C64920C0097C732 /* SharedProtocol */,
 				C04967CE2C64979A0097C732 /* SharedView */,
@@ -1000,7 +1009,6 @@
 		C04967C82C6496B80097C732 /* Setting */ = {
 			isa = PBXGroup;
 			children = (
-				C04967CA2C6496C00097C732 /* ViewModel */,
 				C04967C92C6496BC0097C732 /* View */,
 			);
 			path = Setting;
@@ -1013,13 +1021,6 @@
 				C017C4402C1C3AA3009924C9 /* SettingView.swift */,
 			);
 			path = View;
-			sourceTree = "<group>";
-		};
-		C04967CA2C6496C00097C732 /* ViewModel */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		C04967CB2C6496CB0097C732 /* WebView */ = {
@@ -1110,6 +1111,7 @@
 				C049678E2C607D3A0097C732 /* ToastType.swift */,
 				C017C46D2C1C3AA3009924C9 /* Tab.swift */,
 				C0113D6B2C3A219300071BF6 /* AlertType.swift */,
+				C0DE62712C6C61C0005937B0 /* DetailViewType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1164,6 +1166,24 @@
 				C0D74A452C1EA6B500A45371 /* Route.swift */,
 			);
 			path = Router;
+			sourceTree = "<group>";
+		};
+		C0DE626E2C6C4562005937B0 /* EventLog */ = {
+			isa = PBXGroup;
+			children = (
+				C0DE62732C6C6306005937B0 /* Model */,
+				C0DE626F2C6C4575005937B0 /* EventLogManager.swift */,
+			);
+			path = EventLog;
+			sourceTree = "<group>";
+		};
+		C0DE62732C6C6306005937B0 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C0DE62742C6C631C005937B0 /* LogEventType.swift */,
+				C0DE62762C6C6338005937B0 /* LogUserPropertyType.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1334,6 +1354,7 @@
 				C04967972C647B390097C732 /* PhotoDetailUseCase.swift in Sources */,
 				C099C35D2C1C3DC00006EF83 /* MainRoute.swift in Sources */,
 				C088F2EB2C27AD7200F92320 /* ImageDataTransferService.swift in Sources */,
+				C0DE62752C6C631C005937B0 /* LogEventType.swift in Sources */,
 				C017C49F2C1C3AA3009924C9 /* GeneratorRouter.swift in Sources */,
 				C017C4A52C1C3AA3009924C9 /* ImageLoaderView.swift in Sources */,
 				C017C4982C1C3AA3009924C9 /* PopupImagePickerView.swift in Sources */,
@@ -1365,6 +1386,7 @@
 				C088F2D62C26567500F92320 /* PHAssetImageService.swift in Sources */,
 				C0113D6F2C3A21B100071BF6 /* CompletedPhotoViewViewModel.swift in Sources */,
 				C017C4992C1C3AA3009924C9 /* API.swift in Sources */,
+				C0DE62722C6C61C0005937B0 /* DetailViewType.swift in Sources */,
 				C017C47E2C1C3AA3009924C9 /* GentiPrimaryButton.swift in Sources */,
 				C0113D8C2C3C002F00071BF6 /* OnboardingView.swift in Sources */,
 				C09596872C4DED5400FC5ECC /* RatingPopup.swift in Sources */,
@@ -1430,6 +1452,7 @@
 				C02843712C32BB8900B84566 /* MainFeedViewModel.swift in Sources */,
 				C0BCC4B82C5885B9009C89C4 /* AuthRepository.swift in Sources */,
 				C0B80E5E2C23C57C0071C3CD /* RequestImageData.swift in Sources */,
+				C0DE62772C6C6338005937B0 /* LogUserPropertyType.swift in Sources */,
 				C09596822C4DED1C00FC5ECC /* CustomPopupModifier.swift in Sources */,
 				C017C4822C1C3AA3009924C9 /* PhotoFrame.swift in Sources */,
 				C0BCC4BE2C5885F8009C89C4 /* TokenRepositoryImpl.swift in Sources */,
@@ -1472,6 +1495,7 @@
 				C048A9062C51BA1500026C80 /* Int+Ext.swift in Sources */,
 				C0113D592C37C19800071BF6 /* HapticRepository.swift in Sources */,
 				C017C4B32C1C3AA3009924C9 /* LoginView.swift in Sources */,
+				C0DE62702C6C4576005937B0 /* EventLogManager.swift in Sources */,
 				C017C3E02C1C39CE009924C9 /* SceneDelegate.swift in Sources */,
 				C0113D5B2C37C1A700071BF6 /* HapticRepositoryImpl.swift in Sources */,
 				C017C4202C1C3A62009924C9 /* GentiApp.swift in Sources */,

--- a/Genti_iOS/Genti_iOS/Application/AppDelegate.swift
+++ b/Genti_iOS/Genti_iOS/Application/AppDelegate.swift
@@ -8,6 +8,7 @@
 import Foundation
 import UIKit
 
+import Amplitude
 import Firebase
 import UserNotifications
 import KakaoSDKCommon
@@ -29,6 +30,21 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // 파이어베이스 설정
         FirebaseApp.configure()
         KakaoSDK.initSDK(appKey: "77d47098298c42fc0400efc76b7f4874")
+        
+        // 앰플리튜드 설정
+        Amplitude.instance().defaultTracking.sessions = true
+        Amplitude.instance().defaultTracking.screenViews = true
+        Amplitude.instance().defaultTracking = AMPDefaultTrackingOptions.initWithAllEnabled()
+        Amplitude.instance().initializeApiKey("9c4392f841b51333441bc80b223af1b6")
+        
+        let identify = AMPIdentify()
+            .setOnce("user_share", value: NSNumber(value: 0))
+            .setOnce("user_picturedownload", value: NSNumber(value: 0))
+            .setOnce("user_main_scroll", value: NSNumber(value: 0))
+            .setOnce("user_promptsuggest_refresh", value: NSNumber(value: 0))
+        guard let identify = identify else { return true }
+        Amplitude.instance().identify(identify)
+        
         
         // 앱 실행 시 사용자에게 알림 허용 권한을 받음
         UNUserNotificationCenter.current().delegate = self

--- a/Genti_iOS/Genti_iOS/Application/GentiApp.swift
+++ b/Genti_iOS/Genti_iOS/Application/GentiApp.swift
@@ -11,7 +11,8 @@ struct GentiApp: View {
 
     var body: some View {
         RoutingView(Router<MainRoute>()) { router in
-            SplashView(splashViewModel: SplashViewModel(router: router, splashUseCase: SplashUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl())))
+            SignInView(viewModel: SignInViewModel(signInUseCase: SignInUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl()), router: .init()))
+//            SplashView(splashViewModel: SplashViewModel(router: router, splashUseCase: SplashUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl())))
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Data/Repositories/ImageRepositoryImpl.swift
+++ b/Genti_iOS/Genti_iOS/Data/Repositories/ImageRepositoryImpl.swift
@@ -27,6 +27,7 @@ final class ImageRepositoryImpl: NSObject, ImageRepository {
             self.continuation = continuation
             guard let image = image else { return continuation.resume(returning: false) }
             UIImageWriteToSavedPhotosAlbum(image, self, #selector(saveCompleted), nil)
+            EventLogManager.shared.addUserPropertyCount(to: .downloadPhoto)
         }
     }
 

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/DetailViewType.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/DetailViewType.swift
@@ -11,12 +11,12 @@ enum DetailViewType {
     case detail
     case detailWithShare
     
-    var pageName: String {
+    var initalPage: PageType {
         switch self {
         case .detail:
-            return "picdone"
+            return .compltedPhoto
         case .detailWithShare:
-            return "mypage"
+            return .profile
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/DetailViewType.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/DetailViewType.swift
@@ -1,0 +1,22 @@
+//
+//  DetailViewType.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/14/24.
+//
+
+import Foundation
+
+enum DetailViewType {
+    case detail
+    case detailWithShare
+    
+    var pageName: String {
+        switch self {
+        case .detail:
+            return "picdone"
+        case .detailWithShare:
+            return "mypage"
+        }
+    }
+}

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/OnboardingStep.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/OnboardingStep.swift
@@ -9,4 +9,40 @@ import Foundation
 
 enum OnboardingStep: CaseIterable {
     case first, second
+    
+    var setLogoWidth: CGFloat {
+        switch self {
+        case .first:
+            return 68
+        case .second:
+            return 154
+        }
+    }
+    
+    var setLogoHight: CGFloat {
+        switch self {
+        case .first:
+            return 23
+        case .second:
+            return 51
+        }
+    }
+    
+    var setLogoTopPadding: CGFloat {
+        switch self {
+        case .first:
+            return 15
+        case .second:
+            return 26
+        }
+    }
+    
+    var setButtonTitle: String {
+        switch self {
+        case .first:
+            return "다음으로"
+        case .second:
+            return "젠티하러 가기"
+        }
+    }
 }

--- a/Genti_iOS/Genti_iOS/Instructure/EventLog/EventLogManager.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/EventLog/EventLogManager.swift
@@ -1,0 +1,34 @@
+//
+//  EventLogManager.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/14/24.
+//
+
+import Foundation
+
+import Amplitude
+
+final class EventLogManager {
+    
+    static let shared = EventLogManager()
+    
+    private init() {}
+    
+    func logEvent(_ type: LogEventType) {
+        Amplitude.instance().logEvent(type.eventName, withEventProperties: type.property)
+    }
+    
+    func addUserPropertyCount(to type: LogUserPropertyType) {
+        let identify = AMPIdentify().add(type.propertyName, value: NSNumber(value: 1))
+        guard let identify = identify else {return}
+        Amplitude.instance().identify(identify)
+    }
+
+    func addUserProperty(to type: LogUserPropertyType) {
+        guard let dict = type.property, let key = dict.keys.first, let value = dict[key] as? NSObject else { return }
+        let identify = AMPIdentify().set(key, value: value)
+        guard let identify = identify else {return}
+        Amplitude.instance().identify(identify)
+    }
+}

--- a/Genti_iOS/Genti_iOS/Instructure/EventLog/EventLogManager.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/EventLog/EventLogManager.swift
@@ -12,7 +12,8 @@ import Amplitude
 final class EventLogManager {
     
     static let shared = EventLogManager()
-    
+    private let addCountQueue = DispatchQueue(label: "addPropertyCountQueue", attributes: .concurrent)
+
     private init() {}
     
     func logEvent(_ type: LogEventType) {
@@ -20,9 +21,11 @@ final class EventLogManager {
     }
     
     func addUserPropertyCount(to type: LogUserPropertyType) {
-        let identify = AMPIdentify().add(type.propertyName, value: NSNumber(value: 1))
-        guard let identify = identify else {return}
-        Amplitude.instance().identify(identify)
+        addCountQueue.async(flags: .barrier) {
+            let identify = AMPIdentify().add(type.propertyName, value: NSNumber(value: 1))
+            guard let identify = identify else {return}
+            Amplitude.instance().identify(identify)
+        }
     }
 
     func addUserProperty(to type: LogUserPropertyType) {

--- a/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogEventType.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogEventType.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum LogEventType {
     case singIn(type: GentiSocialLoginType)
-    case clickButton(pageName: String, buttonName: String)
+    case clickButton(page: PageType, buttonName: String)
     case viewInfoget
     case completeInfoget
     case scrollMainView
@@ -31,7 +31,7 @@ enum LogEventType {
         switch self {
         case .singIn:
             return "sign_in"
-        case .clickButton(let pageName, let buttonName):
+        case .clickButton:
             return "click_button"
         case .viewInfoget:
             return "view_infoget"
@@ -72,8 +72,8 @@ enum LogEventType {
         switch self {
         case .singIn(let type):
             return ["signup_method": type.rawValue]
-        case .clickButton(let pageName, let buttonName):
-            return ["page_name": pageName, "button_name": buttonName]
+        case .clickButton(let page, let buttonName):
+            return ["page_name": page.pageName, "button_name": buttonName]
         default:
             return nil
         }

--- a/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogEventType.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogEventType.swift
@@ -1,0 +1,81 @@
+//
+//  LogEventType.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/14/24.
+//
+
+import Foundation
+
+enum LogEventType {
+    case singIn(type: GentiSocialLoginType)
+    case clickButton(pageName: String, buttonName: String)
+    case viewInfoget
+    case completeInfoget
+    case scrollMainView
+    case refreshMainView
+    case clickMainTab
+    case clickCreateTab
+    case clickMyPageTab
+    case clickDisableButtonInSecondGeneratorView
+    case addThreeUserPickture
+    case enlargePhoto
+    case downloadPhoto
+    case reportPhoto
+    case sendPhotoRating
+    case skipPhotoRating
+    case logout
+    case resign
+    
+    var eventName: String {
+        switch self {
+        case .singIn:
+            return "sign_in"
+        case .clickButton(let pageName, let buttonName):
+            return "click_button"
+        case .viewInfoget:
+            return "view_infoget"
+        case .scrollMainView:
+            return "scroll_main"
+        case .refreshMainView:
+            return "refresh_main"
+        case .clickMainTab:
+            return "click_maintab"
+        case .clickCreateTab:
+            return "click_createpictab"
+        case .clickMyPageTab:
+            return "click_mypagetab"
+        case .clickDisableButtonInSecondGeneratorView:
+            return "click_create2_next_gray"
+        case .addThreeUserPickture:
+            return "add_create3_userpic3"
+        case .completeInfoget:
+            return "complete_infoget"
+        case .enlargePhoto:
+            return "enlarge_mypage_picture"
+        case .downloadPhoto:
+            return "download_picdone_enlargedpicture"
+        case .reportPhoto:
+            return "reportpic_picdone"
+        case .sendPhotoRating:
+            return "ratingsubmit_picdone"
+        case .skipPhotoRating:
+            return "ratingpass_picdone"
+        case .logout:
+            return "log_out"
+        case .resign:
+            return "sign_out"
+        }
+    }
+    
+    var property: [String: String]? {
+        switch self {
+        case .singIn(let type):
+            return ["signup_method": type.rawValue]
+        case .clickButton(let pageName, let buttonName):
+            return ["page_name": pageName, "button_name": buttonName]
+        default:
+            return nil
+        }
+    }
+}

--- a/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogUserPropertyType.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogUserPropertyType.swift
@@ -1,0 +1,40 @@
+//
+//  LogUserPropertyType.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/14/24.
+//
+
+import Foundation
+
+enum LogUserPropertyType {
+    case userEmail(email: String)
+    case shareButtonTap
+    case downloadPhoto
+    case scrollMainView
+    case refreshMainView
+    
+    var propertyName: String {
+        switch self {
+        case .userEmail:
+            return "user_email"
+        case .shareButtonTap:
+            return "user_share"
+        case .downloadPhoto:
+            return "user_picturedownload"
+        case .scrollMainView:
+            return "user_main_scroll"
+        case .refreshMainView:
+            return "user_promptsuggest_refresh"
+        }
+    }
+    
+    var property: [String: Any]? {
+        switch self {
+        case .userEmail(let email):
+            return ["email": email]
+        default:
+            return nil
+        }
+    }
+}

--- a/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/PageType.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/PageType.swift
@@ -1,0 +1,40 @@
+//
+//  PageType.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 8/14/24.
+//
+
+import Foundation
+
+enum PageType {
+    case onboarding1
+    case onboarding2
+    case firstGenerator
+    case secondGenerator
+    case thirdGenerator
+    case requestCompleted
+    case profile
+    case compltedPhoto
+    
+    var pageName: String {
+        switch self {
+        case .onboarding1:
+            return "onboarding1"
+        case .onboarding2:
+            return "onboarding2"
+        case .firstGenerator:
+            return "create1"
+        case .secondGenerator:
+            return "create2"
+        case .thirdGenerator:
+            return "create3"
+        case .requestCompleted:
+            return "picwaiting"
+        case .profile:
+            return "mypage"
+        case .compltedPhoto:
+            return "picdone"
+        }
+    }
+}

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/CompletedPhotoView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/CompletedPhotoView.swift
@@ -30,6 +30,9 @@ struct CompletedPhotoView: View {
                         .shareStyle()
                 }
                 .disabled(viewModel.disabled)
+                .onTapGesture {
+                    self.viewModel.sendAction(.shareButtonTap)
+                }
                 
                 Spacer()
                     .frame(height: 18)

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/ViewModel/CompletedPhotoViewViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/ViewModel/CompletedPhotoViewViewModel.swift
@@ -45,7 +45,7 @@ final class CompletedPhotoViewViewModel: ViewModel {
     func sendAction(_ input: Input) {
         switch input {
         case .goToMainButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "picdone", buttonName: "gomain"))
+            EventLogManager.shared.logEvent(.clickButton(page: .compltedPhoto, buttonName: "gomain"))
             self.state.showRatingView = true
         case .reportButtonTap:
             presentReportAlert()
@@ -59,7 +59,7 @@ final class CompletedPhotoViewViewModel: ViewModel {
             self.router.dismissSheet()
         case .shareButtonTap:
             EventLogManager.shared.addUserPropertyCount(to: .shareButtonTap)
-            EventLogManager.shared.logEvent(.clickButton(pageName: "picdone", buttonName: "picshare"))
+            EventLogManager.shared.logEvent(.clickButton(page: .compltedPhoto, buttonName: "picshare"))
         }
     }
     
@@ -67,7 +67,7 @@ final class CompletedPhotoViewViewModel: ViewModel {
     func downloadImage() async {
         do {
             if await completedPhotoUseCase.downloadImage(to: state.image) {
-                EventLogManager.shared.logEvent(.clickButton(pageName: "picdone", buttonName: "picdownload"))
+                EventLogManager.shared.logEvent(.clickButton(page: .compltedPhoto, buttonName: "picdownload"))
                 state.showToast = .success
             } else {
                 state.showToast = .failure

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/ViewModel/CompletedPhotoViewViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/ViewModel/CompletedPhotoViewViewModel.swift
@@ -58,6 +58,7 @@ final class CompletedPhotoViewViewModel: ViewModel {
         case .ratingActionIsDone:
             self.router.dismissSheet()
         case .shareButtonTap:
+            EventLogManager.shared.addUserPropertyCount(to: .shareButtonTap)
             EventLogManager.shared.logEvent(.clickButton(pageName: "picdone", buttonName: "picshare"))
         }
     }

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/ViewModel/CompletedPhotoViewViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/ViewModel/CompletedPhotoViewViewModel.swift
@@ -39,11 +39,13 @@ final class CompletedPhotoViewViewModel: ViewModel {
         case imageTap
         case downloadButtonTap
         case ratingActionIsDone
+        case shareButtonTap
     }
 
     func sendAction(_ input: Input) {
         switch input {
         case .goToMainButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "picdone", buttonName: "gomain"))
             self.state.showRatingView = true
         case .reportButtonTap:
             presentReportAlert()
@@ -55,6 +57,8 @@ final class CompletedPhotoViewViewModel: ViewModel {
             Task { await downloadImage() }
         case .ratingActionIsDone:
             self.router.dismissSheet()
+        case .shareButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "picdone", buttonName: "picshare"))
         }
     }
     
@@ -62,6 +66,7 @@ final class CompletedPhotoViewViewModel: ViewModel {
     func downloadImage() async {
         do {
             if await completedPhotoUseCase.downloadImage(to: state.image) {
+                EventLogManager.shared.logEvent(.clickButton(pageName: "picdone", buttonName: "picdownload"))
                 state.showToast = .success
             } else {
                 state.showToast = .failure
@@ -96,6 +101,7 @@ final class CompletedPhotoViewViewModel: ViewModel {
             try await completedPhotoUseCase.reportPhoto(responseId: photoInfo.responseId, content: state.reportContent)
             state.reportContent = ""
             state.isLoading = false
+            EventLogManager.shared.logEvent(.reportPhoto)
             state.showAlert = .reportComplete(action: { self.router.dismissSheet() })
         } catch(let error) {
             state.reportContent = ""
@@ -110,6 +116,7 @@ final class CompletedPhotoViewViewModel: ViewModel {
 
     private func navigateToPhotoExpandView() {
         guard let image = state.image else { return }
+        EventLogManager.shared.logEvent(.enlargePhoto)
         self.router.routeTo(.photoDetail(image: image))
     }
     

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/View/GenerateRequestCompleteView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/View/GenerateRequestCompleteView.swift
@@ -55,6 +55,7 @@ struct GenerateRequestCompleteView: View {
                 Spacer(minLength: 0)
                 
                 GentiPrimaryButton(title: "피드로 돌아가기", isActive: true) {
+                    EventLogManager.shared.logEvent(.clickButton(pageName: "picwaiting", buttonName: "gomain"))
                     router.dismissSheet()
                 }
                 .padding(.bottom, 30)

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/View/GenerateRequestCompleteView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/View/GenerateRequestCompleteView.swift
@@ -55,7 +55,7 @@ struct GenerateRequestCompleteView: View {
                 Spacer(minLength: 0)
                 
                 GentiPrimaryButton(title: "피드로 돌아가기", isActive: true) {
-                    EventLogManager.shared.logEvent(.clickButton(pageName: "picwaiting", buttonName: "gomain"))
+                    EventLogManager.shared.logEvent(.clickButton(page: .requestCompleted, buttonName: "gomain"))
                     router.dismissSheet()
                 }
                 .padding(.bottom, 30)

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/View/SecondGeneratorView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/View/SecondGeneratorView.swift
@@ -37,6 +37,11 @@ struct SecondGeneratorView: View {
         GentiPrimaryButton(title: "다음으로", isActive: viewModel.isActive) {
             viewModel.sendAction(.nextButtonTap)
         }
+        .onTapGesture {
+            if !viewModel.isActive {
+                viewModel.sendAction(.disabledButtonTap)
+            }
+        }
         .padding(.bottom, 32)
     }
     

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/FirstGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/FirstGeneratorViewModel.swift
@@ -46,7 +46,7 @@ final class FirstGeneratorViewModel: ViewModel, GetImageFromImagePicker {
             state.currentIndex = (state.currentIndex + 1) % randomDescription.count
             state.currentRandomDescriptionExample = randomDescription[state.currentIndex]
         case .randomButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create1", buttonName: "promptsuggest_refresh"))
+            EventLogManager.shared.logEvent(.clickButton(page: .firstGenerator, buttonName: "promptsuggest_refresh"))
             state.currentIndex = (state.currentIndex + 1) % randomDescription.count
             state.currentRandomDescriptionExample = randomDescription[state.currentIndex]
         case .inputDescription(let text):
@@ -54,10 +54,10 @@ final class FirstGeneratorViewModel: ViewModel, GetImageFromImagePicker {
         case .addImageButtonTap:
             showImagePicker()
         case .nextButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create1", buttonName: "next"))
+            EventLogManager.shared.logEvent(.clickButton(page: .firstGenerator, buttonName: "next"))
             self.router.routeTo(.secondGen(data: self.requestData()))
         case .xmarkTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create1", buttonName: "exit"))
+            EventLogManager.shared.logEvent(.clickButton(page: .firstGenerator, buttonName: "exit"))
             self.router.dismissSheet()
         case .removeButtonTap:
             self.removeReferenceImage()

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/FirstGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/FirstGeneratorViewModel.swift
@@ -46,6 +46,7 @@ final class FirstGeneratorViewModel: ViewModel, GetImageFromImagePicker {
             state.currentIndex = (state.currentIndex + 1) % randomDescription.count
             state.currentRandomDescriptionExample = randomDescription[state.currentIndex]
         case .randomButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create1", buttonName: "promptsuggest_refresh"))
             state.currentIndex = (state.currentIndex + 1) % randomDescription.count
             state.currentRandomDescriptionExample = randomDescription[state.currentIndex]
         case .inputDescription(let text):
@@ -53,8 +54,10 @@ final class FirstGeneratorViewModel: ViewModel, GetImageFromImagePicker {
         case .addImageButtonTap:
             showImagePicker()
         case .nextButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create1", buttonName: "next"))
             self.router.routeTo(.secondGen(data: self.requestData()))
         case .xmarkTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create1", buttonName: "exit"))
             self.router.dismissSheet()
         case .removeButtonTap:
             self.removeReferenceImage()

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/SecondGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/SecondGeneratorViewModel.swift
@@ -49,10 +49,13 @@ final class SecondGeneratorViewModel: ViewModel {
         case .ratioTap(let photoRatio):
             state.selectedRatio = photoRatio
         case .nextButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create2", buttonName: "next"))
             self.router.routeTo(.thirdGen(data: self.requestData()))
         case .xmarkTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create2", buttonName: "exit"))
             self.router.dismissSheet()
         case .backButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create2", buttonName: "back"))
             self.router.dismiss()
         case .viewWillAppear:
             if userdefaultRepository.isFirstGenerate {

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/SecondGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/SecondGeneratorViewModel.swift
@@ -49,13 +49,13 @@ final class SecondGeneratorViewModel: ViewModel {
         case .ratioTap(let photoRatio):
             state.selectedRatio = photoRatio
         case .nextButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create2", buttonName: "next"))
+            EventLogManager.shared.logEvent(.clickButton(page: .secondGenerator, buttonName: "next"))
             self.router.routeTo(.thirdGen(data: self.requestData()))
         case .xmarkTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create2", buttonName: "exit"))
+            EventLogManager.shared.logEvent(.clickButton(page: .secondGenerator, buttonName: "exit"))
             self.router.dismissSheet()
         case .backButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create2", buttonName: "back"))
+            EventLogManager.shared.logEvent(.clickButton(page: .secondGenerator, buttonName: "back"))
             self.router.dismiss()
         case .viewWillAppear:
             if userdefaultRepository.isFirstGenerate {

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/SecondGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/SecondGeneratorViewModel.swift
@@ -37,6 +37,7 @@ final class SecondGeneratorViewModel: ViewModel {
         case xmarkTap
         case backButtonTap
         case viewWillAppear
+        case disabledButtonTap
     }
     
     func sendAction(_ input: Input) {
@@ -57,6 +58,8 @@ final class SecondGeneratorViewModel: ViewModel {
             if userdefaultRepository.isFirstGenerate {
                 self.state.showOnboarding.toggle()
             }
+        case .disabledButtonTap:
+            EventLogManager.shared.logEvent(.clickDisableButtonInSecondGeneratorView)
         }
     }
     

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/ThirdGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/ThirdGeneratorViewModel.swift
@@ -41,16 +41,16 @@ final class ThirdGeneratorViewModel: ViewModel, GetImageFromImagePicker {
     func sendAction(_ input: Input) {
         switch input {
         case .addImageButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "selectpic"))
+            EventLogManager.shared.logEvent(.clickButton(page: .thirdGenerator, buttonName: "selectpic"))
             showImagePicker()
         case .reChoiceButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "reselectpic"))
+            EventLogManager.shared.logEvent(.clickButton(page: .thirdGenerator, buttonName: "reselectpic"))
             showImagePicker()
         case .backButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "back"))
+            EventLogManager.shared.logEvent(.clickButton(page: .thirdGenerator, buttonName: "back"))
             router.dismiss()
         case .xmarkTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "exit"))
+            EventLogManager.shared.logEvent(.clickButton(page: .thirdGenerator, buttonName: "exit"))
             router.dismissSheet()
         case .nextButtonTap:
             Task { await completeImageRequest() }
@@ -62,7 +62,7 @@ final class ThirdGeneratorViewModel: ViewModel, GetImageFromImagePicker {
         do {
             state.isLoading = true
             try await imageGenerateUseCase.requestImage(from: self.requestData())
-            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "createpic"))
+            EventLogManager.shared.logEvent(.clickButton(page: .thirdGenerator, buttonName: "createpic"))
             state.isLoading = false
             router.routeTo(.requestCompleted)
         } catch(let error) {

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/ThirdGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/ThirdGeneratorViewModel.swift
@@ -40,11 +40,17 @@ final class ThirdGeneratorViewModel: ViewModel, GetImageFromImagePicker {
     
     func sendAction(_ input: Input) {
         switch input {
-        case .addImageButtonTap, .reChoiceButtonTap:
+        case .addImageButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "selectpic"))
+            showImagePicker()
+        case .reChoiceButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "reselectpic"))
             showImagePicker()
         case .backButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "back"))
             router.dismiss()
         case .xmarkTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "exit"))
             router.dismissSheet()
         case .nextButtonTap:
             Task { await completeImageRequest() }
@@ -56,6 +62,7 @@ final class ThirdGeneratorViewModel: ViewModel, GetImageFromImagePicker {
         do {
             state.isLoading = true
             try await imageGenerateUseCase.requestImage(from: self.requestData())
+            EventLogManager.shared.logEvent(.clickButton(pageName: "create3", buttonName: "createpic"))
             state.isLoading = false
             router.routeTo(.requestCompleted)
         } catch(let error) {

--- a/Genti_iOS/Genti_iOS/Presentation/Home/ViewModel/MainFeedViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Home/ViewModel/MainFeedViewModel.swift
@@ -46,9 +46,14 @@ final class MainFeedViewModel: ViewModel {
             checkUserFirstVisit()
         case .scroll(offset: let offset):
             state.isLogoHidden = offset < 165 ? true : false
+            if offset > 165*3 {
+                EventLogManager.shared.addUserPropertyCount(to: .scrollMainView)
+                EventLogManager.shared.logEvent(.scrollMainView)}
         case .genfluencerExplainTap:
             router.routeTo(.webView(url: "https://stealth-goose-156.notion.site/57a00e1d610b4c1786c6ab1fdb4c4659?pvs=4"))
         case .refresh:
+            EventLogManager.shared.addUserPropertyCount(to: .refreshMainView)
+            EventLogManager.shared.logEvent(.refreshMainView)
             state.feeds = state.feeds.shuffled()
         }
     }

--- a/Genti_iOS/Genti_iOS/Presentation/ImagePicker/ViewModel/ImagePickerViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/ImagePicker/ViewModel/ImagePickerViewModel.swift
@@ -43,6 +43,7 @@ final class ImagePickerViewModel: ViewModel {
             router.dismissSheet()
         case .addImageButtonTap:
             generatorViewModel.setReferenceImageAssets(assets: state.selectedImages)
+            if limit == 3 { EventLogManager.shared.logEvent(.addThreeUserPickture) }
             router.dismissSheet()
         case .viewDidAppear:
             state.selectedImages.removeAll()

--- a/Genti_iOS/Genti_iOS/Presentation/Onboarding/View/OnboardingView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Onboarding/View/OnboardingView.swift
@@ -16,8 +16,8 @@ struct OnboardingView: View {
             Image(.gentiLOGO)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(width: viewModel.setLogoWidth, height: viewModel.setLogoHight)
-                .padding(.top, viewModel.setLogoTopPadding)
+                .frame(width: viewModel.state.step.setLogoWidth, height: viewModel.state.step.setLogoHight)
+                .padding(.top, viewModel.state.step.setLogoTopPadding)
             
             Spacer()
             
@@ -50,7 +50,7 @@ struct OnboardingView: View {
                 }
             }
             
-            GentiPrimaryButton(title: viewModel.setButtonTitle, isActive: true) {
+            GentiPrimaryButton(title: viewModel.state.step.setButtonTitle, isActive: true) {
                 viewModel.sendAction(.nextButtonTap)
             }
             .padding(.vertical, 18)

--- a/Genti_iOS/Genti_iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -22,14 +22,14 @@ final class OnboardingViewModel: ViewModel {
         case .nextButtonTap:
             switch state.step {
             case .first:
-                EventLogManager.shared.logEvent(.clickButton(pageName: "onboarding1", buttonName: "next"))
+                EventLogManager.shared.logEvent(.clickButton(page: .onboarding1, buttonName: "next"))
                 state.step = .second
             case .second:
-                EventLogManager.shared.logEvent(.clickButton(pageName: "onboarding2", buttonName: "gogenti"))
+                EventLogManager.shared.logEvent(.clickButton(page: .onboarding2, buttonName: "gogenti"))
                 self.router.dismissSheet()
             }
         case .xmarkTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "onboarding1", buttonName: "exit"))
+            EventLogManager.shared.logEvent(.clickButton(page: .onboarding1, buttonName: "exit"))
             self.router.dismissSheet()
         }
     }

--- a/Genti_iOS/Genti_iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -44,42 +44,6 @@ final class OnboardingViewModel: ViewModel {
         case xmarkTap
     }
     
-    var setLogoWidth: CGFloat {
-        switch state.step {
-        case .first:
-            return 68
-        case .second:
-            return 154
-        }
-    }
-    
-    var setLogoHight: CGFloat {
-        switch state.step {
-        case .first:
-            return 23
-        case .second:
-            return 51
-        }
-    }
-    
-    var setLogoTopPadding: CGFloat {
-        switch state.step {
-        case .first:
-            return 15
-        case .second:
-            return 26
-        }
-    }
-    
-    var setButtonTitle: String {
-        switch state.step {
-        case .first:
-            return "다음으로"
-        case .second:
-            return "젠티하러 가기"
-        }
-    }
-    
     func setPageControl(from step: OnboardingStep) -> Color {
         if step == state.step {
             return .gentiGreen

--- a/Genti_iOS/Genti_iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -22,11 +22,14 @@ final class OnboardingViewModel: ViewModel {
         case .nextButtonTap:
             switch state.step {
             case .first:
+                EventLogManager.shared.logEvent(.clickButton(pageName: "onboarding1", buttonName: "next"))
                 state.step = .second
             case .second:
+                EventLogManager.shared.logEvent(.clickButton(pageName: "onboarding2", buttonName: "gogenti"))
                 self.router.dismissSheet()
             }
         case .xmarkTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "onboarding1", buttonName: "exit"))
             self.router.dismissSheet()
         }
     }

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailView.swift
@@ -23,7 +23,7 @@ struct PhotoDetailView: View {
                     .padding(.trailing, 10)
                     .padding(.bottom, 10)
                     .asButton {
-                        self.viewModel.sendAction(.downloadButtonTap)
+                        self.viewModel.sendAction(.downloadButtonTap(from: .detail))
                     }
             }
             .padding(.horizontal, 28)

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailWithShareView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailWithShareView.swift
@@ -28,6 +28,9 @@ struct PhotoDetailWithShareView: View {
                 Text("공유하기")
                     .shareStyle()
             }
+            .onTapGesture {
+                viewModel.sendAction(.shareButtonTap)
+            }
             
         }
         .addXmark(top: 3, trailing: 20) { viewModel.sendAction(.xmarkTap) }

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailWithShareView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailWithShareView.swift
@@ -20,7 +20,7 @@ struct PhotoDetailWithShareView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .addDownloadButton {
-                            viewModel.sendAction(.downloadButtonTap) }
+                            viewModel.sendAction(.downloadButtonTap(from: .detailWithShare)) }
                 }
                 .padding(.horizontal, 30)
             

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
@@ -20,7 +20,7 @@ final class PhotoDetailViewModel: ViewModel {
         var showToast: ToastType? = nil
     }
     enum Input {
-        case downloadButtonTap
+        case downloadButtonTap(from: DetailViewType)
         case xmarkTap
         case backgroundTap
         case shareButtonTap
@@ -36,8 +36,8 @@ final class PhotoDetailViewModel: ViewModel {
     
     func sendAction(_ input: Input) {
         switch input {
-        case .downloadButtonTap:
-            Task { await download() }
+        case .downloadButtonTap(let type):
+            Task { await download(type: type) }
         case .xmarkTap, .backgroundTap:
             router.dismissSheet()
         case .shareButtonTap:
@@ -46,15 +46,14 @@ final class PhotoDetailViewModel: ViewModel {
     }
     
     @MainActor
-    func download() async {
+    func download(type: DetailViewType) async {
         do {
             if await photoDetailUseCase.downloadImage(to: state.image) {
-                EventLogManager.shared.logEvent(.clickButton(pageName: "mypage", buttonName: "picdownload"))
+                EventLogManager.shared.logEvent(.clickButton(pageName: type.pageName, buttonName: "picdownload"))
                 state.showToast = .success
             } else {
                 state.showToast = .failure
             }
-            
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
@@ -23,6 +23,7 @@ final class PhotoDetailViewModel: ViewModel {
         case downloadButtonTap
         case xmarkTap
         case backgroundTap
+        case shareButtonTap
     }
     
     var state: State
@@ -39,6 +40,8 @@ final class PhotoDetailViewModel: ViewModel {
             Task { await download() }
         case .xmarkTap, .backgroundTap:
             router.dismissSheet()
+        case .shareButtonTap:
+            EventLogManager.shared.logEvent(.clickButton(pageName: "mypage", buttonName: "picshare"))
         }
     }
     
@@ -46,6 +49,7 @@ final class PhotoDetailViewModel: ViewModel {
     func download() async {
         do {
             if await photoDetailUseCase.downloadImage(to: state.image) {
+                EventLogManager.shared.logEvent(.clickButton(pageName: "mypage", buttonName: "picdownload"))
                 state.showToast = .success
             } else {
                 state.showToast = .failure

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
@@ -41,7 +41,7 @@ final class PhotoDetailViewModel: ViewModel {
         case .xmarkTap, .backgroundTap:
             router.dismissSheet()
         case .shareButtonTap:
-            EventLogManager.shared.logEvent(.clickButton(pageName: "mypage", buttonName: "picshare"))
+            EventLogManager.shared.logEvent(.clickButton(page: .profile, buttonName: "picshare"))
             EventLogManager.shared.addUserPropertyCount(to: .shareButtonTap)
         }
     }
@@ -50,7 +50,7 @@ final class PhotoDetailViewModel: ViewModel {
     func download(type: DetailViewType) async {
         do {
             if await photoDetailUseCase.downloadImage(to: state.image) {
-                EventLogManager.shared.logEvent(.clickButton(pageName: type.pageName, buttonName: "picdownload"))
+                EventLogManager.shared.logEvent(.clickButton(page: type.initalPage, buttonName: "picdownload"))
                 state.showToast = .success
             } else {
                 state.showToast = .failure

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
@@ -42,6 +42,7 @@ final class PhotoDetailViewModel: ViewModel {
             router.dismissSheet()
         case .shareButtonTap:
             EventLogManager.shared.logEvent(.clickButton(pageName: "mypage", buttonName: "picshare"))
+            EventLogManager.shared.addUserPropertyCount(to: .shareButtonTap)
         }
     }
     

--- a/Genti_iOS/Genti_iOS/Presentation/PopUp/ViewModel/RatingAlertViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PopUp/ViewModel/RatingAlertViewModel.swift
@@ -53,6 +53,7 @@ final class RatingAlertViewModel: ViewModel {
         do {
             self.state.isLoading = true
             try await userRepository.scorePhoto(responseId: photoInfo.responseId, rate: state.rating)
+            EventLogManager.shared.logEvent(.sendPhotoRating)
         } catch(let error) {
             print(error)
         }
@@ -68,6 +69,7 @@ final class RatingAlertViewModel: ViewModel {
         do {
             self.state.isLoading = true
             try await userRepository.checkCompletedImage(responeId: photoInfo.responseId)
+            EventLogManager.shared.logEvent(.skipPhotoRating)
         } catch(let error) {
             print(error)
         }

--- a/Genti_iOS/Genti_iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -35,6 +35,7 @@ final class ProfileViewModel: ViewModel {
     func sendAction(_ input: Input) {
         switch input {
         case .imageTap(let url):
+            EventLogManager.shared.logEvent(.enlargePhoto)
             Task { await showMyImage(url: url) }
         case .gearButtonTap:
             router.routeTo(.setting)

--- a/Genti_iOS/Genti_iOS/Presentation/Setting/View/SettingView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Setting/View/SettingView.swift
@@ -62,10 +62,12 @@ struct SettingView: View {
             try await requestService.fetchResponse(for: AuthRouter.resign)
             userdefaultRepository.removeToken()
             userdefaultRepository.removeUserRole()
+            EventLogManager.shared.logEvent(.resign)
             self.isLoading = false
             router.popToRoot()
-        } catch {
-            
+        } catch(let error) {
+            self.isLoading = false
+            print(error)
         }
     }
     
@@ -76,9 +78,11 @@ struct SettingView: View {
             try await requestService.fetchResponse(for: AuthRouter.logout)
             userdefaultRepository.removeToken()
             userdefaultRepository.removeUserRole()
+            EventLogManager.shared.logEvent(.logout)
             self.isLoading = false
             router.popToRoot()
         } catch(let error) {
+            self.isLoading = false
             print(error)
         }
     }

--- a/Genti_iOS/Genti_iOS/Presentation/SignIn/View/SignInView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/SignIn/View/SignInView.swift
@@ -29,6 +29,9 @@ struct SignInView: View {
                 LoadingView()
             }
         }
+        .onAppear {
+            self.viewModel.sendAction(.viewWillAppear)
+        }
         .toolbar(.hidden, for: .navigationBar)
         .customAlert(alertType: $viewModel.state.showAlert)
     }

--- a/Genti_iOS/Genti_iOS/Presentation/SignIn/ViewModel/SignInViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/SignIn/ViewModel/SignInViewModel.swift
@@ -65,8 +65,11 @@ final class SignInViewModel: ViewModel {
     func postUserInformation() async {
         do {
             state.isLoading = true
-            try await signInUseCase.signIn(gender: state.gender, birthYear: state.birthYear)
+//            try await signInUseCase.signIn(gender: state.gender, birthYear: state.birthYear)
             EventLogManager.shared.logEvent(.completeInfoget)
+            // MARK: - 추후 수정
+            EventLogManager.shared.logEvent(.singIn(type: .apple))
+            EventLogManager.shared.addUserProperty(to: .userEmail(email: "테스트이메일입니다"))
             state.isLoading = false
             router.routeTo(.mainTab)
         } catch(let error) {

--- a/Genti_iOS/Genti_iOS/Presentation/SignIn/ViewModel/SignInViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/SignIn/ViewModel/SignInViewModel.swift
@@ -27,6 +27,7 @@ final class SignInViewModel: ViewModel {
     }
     
     enum Input {
+        case viewWillAppear
         case backgroundTap
         case genderSelect(Gender)
         case birthYearSelect
@@ -41,6 +42,8 @@ final class SignInViewModel: ViewModel {
     
     func sendAction(_ input: Input) {
         switch input {
+        case .viewWillAppear:
+            EventLogManager.shared.logEvent(.viewInfoget)
         case .genderSelect(let gender):
             self.state.gender = gender
         case .birthYearSelect:
@@ -54,6 +57,7 @@ final class SignInViewModel: ViewModel {
             if state.showPicker {
                 state.showPicker = false
             }
+
         }
     }
     
@@ -62,6 +66,7 @@ final class SignInViewModel: ViewModel {
         do {
             state.isLoading = true
             try await signInUseCase.signIn(gender: state.gender, birthYear: state.birthYear)
+            EventLogManager.shared.logEvent(.completeInfoget)
             state.isLoading = false
             router.routeTo(.mainTab)
         } catch(let error) {

--- a/Genti_iOS/Genti_iOS/Presentation/TabView/View/CustomTabView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/TabView/View/CustomTabView.swift
@@ -20,6 +20,7 @@ struct CustomTabView: View {
                 .padding(3)
                 .background(.black.opacity(0.001))
                 .onTapGesture {
+                    EventLogManager.shared.logEvent(.clickMainTab)
                     viewModel.sendAction(.feedIconTap)
                 }
             Spacer()
@@ -29,6 +30,7 @@ struct CustomTabView: View {
                 .padding(3)
                 .background(.black.opacity(0.001))
                 .onTapGesture {
+                    EventLogManager.shared.logEvent(.clickCreateTab)
                     viewModel.sendAction(.cameraIconTap)
                 }
 
@@ -41,6 +43,7 @@ struct CustomTabView: View {
                 .padding(3)
                 .background(.black.opacity(0.001))
                 .onTapGesture {
+                    EventLogManager.shared.logEvent(.clickMyPageTab)
                     viewModel.sendAction(.profileIconTap)
                 }
         }


### PR DESCRIPTION
## [#75] FEAT : Amplitude추가

## 🌱 작업한 내용
- event log 측정
- user property 값 세팅
- user property 값 누적

## 🌱 PR Point
## 1. singleton으로 EventLogManager생성
```swift
final class EventLogManager {
    static let shared = EventLogManager()
    private init() {}

    func logEvent(_ type: LogEventType) { ...생략... }
    func addUserPropertyCount(to type: LogUserPropertyType) { ...생략... }
    func addUserProperty(to type: LogUserPropertyType) { ...생략... }
}
```
### 싱글톤을 선택한 두가지 이유
#### 1. event log기록이 전역적으로 사용되기때문
- 예를들어서 이미지 다운로드의 경우엔 최종적으로 repository에서 동작이 일어나기에 `사진다운로드`의 경우엔 repository에 event log만 찍어도 이미지 다운하는 모든 뷰에서의 action을 남길수있으나 단순히 버튼을 tap하는 이벤트의 loging의 경우 viewmodel에서 이루어질때가 많았습니다(통신없이 진행되는경우) 해당 경우가 섞여있어 log를 처리하는 repository를 만들기엔 애매한 부분이 많아 전역적으로 사용할수있는 singleton을 선택했습니다

#### 2. thread safe한 상황 만들기
- singleton은 생성시에는 static let으로 인해 atomic함을 보장받습니다. singleton이 anti pattern이라고 불리는 경우에는 값을 읽고쓰는 과정에서는 thread safe하지 않기때문인데 현재상황은 값을 읽는 코드는없고 사실상 값을 쓰기만하는 case만 존재하기에 표면적으로는 data race가 발생하지 않을거라고 생각해 singleton의 장점만 가져올수있는 상황이라고 생각했습니다. 물론 여러스레드에서 동시에 add하게되는 상황이 생길수있어 정확히 200번 터치했지만 200번이라는 숫자가 data race로인해 도출되지 않을 가능성도 무시할수는 없다고 생각해 add하는 task 자체를 atomic하게 묶어주는 코드를 추가했습니다
> [!NOTE]  
> add라는 동작자체가 문제가 되는 경우는 값을 read해서 값을 더하고 값을 다시 write하는 과정이 atomic하지 않기때문에 발생하게되는데 현재코드는 read해서 다시 write하는 코드는 아니고 단순히 add하는 동작을 보내기때문에 data race가 발생하지 않거나 amplitude내부에서 이러한 문제를 해결했을수있으나 `Amplitude.instance().identify(identify)` 이 코드처럼 업데이트하고 다시 instance를 갱신해주는 코드때문에 문제가 발생할수도있지않을까라는 생각이 들었습니다. 단순히 `1더하라는 동작`을 보내는 거라면 datarace가 발생하지 않겠으나 내부가 objc코드로 작성이되어있어 혹시모를 변수에 대비한 코드라고 생각하시면 됩니다
```swift
private let addCountQueue = DispatchQueue(label: "addPropertyCountQueue", attributes: .concurrent)
func addUserPropertyCount(to type: LogUserPropertyType) {
   addCountQueue.async(flags: .barrier) {
        let identify = AMPIdentify().add(type.propertyName, value: NSNumber(value: 1))
        guard let identify = identify else {return}
        Amplitude.instance().identify(identify)
    }
}
```
- 이렇게되면 값이 add되고 amplitude instance에 업데이트될때까지 다른 작업에 영향을 받지않을수있게됩니다
---

## 2. EventLogManager의 역할
### 1. 유저와 연관없게끔 event를 추적합니다
```swift
func logEvent(_ type: LogEventType) {
    Amplitude.instance().logEvent(type.eventName, withEventProperties: type.property)
}
```
- logEvent라는 메서드에서는 LogEventType을 받아서 각각의 event이름과 property를 기록해줍니다

### 2. 유저와 관계없는 이벤트의 횟수를 누적합니다
```swift
func addUserPropertyCount(to type: LogUserPropertyType) {
    addCountQueue.async(flags: .barrier) {
        let identify = AMPIdentify().add(type.propertyName, value: NSNumber(value: 1))
        guard let identify = identify else {return}
        Amplitude.instance().identify(identify)
    }
}
```
- appdelegate에서 0으로초기화된(앱을 껐다켜도 amplitude sdk에서 값을 기억해줌)값을 특정 액션마다 1씩 누적시킵니다
- 한 유저가 얼마나 사진을 만드는지, 다운로드받는지등의 값을 최종적으로 뽑아낼수있습니다

### 3. 유저의 정보를 기록합니다
- 현재 젠티는 다양한 유저정보를 소셜로그인 서버를 포함해 회원가입을 통해서도 받고있습니다
- 소셜로그인에서는 최소한의 정보, 나머지 정보는 앱자체에서 받고있기때문에 해당 정보들을 저장해야합니다
```swift
func addUserProperty(to type: LogUserPropertyType) {
    guard let dict = type.property, let key = dict.keys.first, let value = dict[key] as? NSObject else { return }
    let identify = AMPIdentify().set(key, value: value)
    guard let identify = identify else {return}
    Amplitude.instance().identify(identify)
}
```
- 특정정보(현재는 회원가입완료시 이메일, 성별, 태어난년도)를 저장합니다
- 각 유저의 정보를 통해 특정 집단의 행동양식을 파악할수있습니다

## 📮 관련 이슈

- Resolved: #75 