### PR TITLE
[RELEASE] 1.1.1버전배포(#83)

### DIFF
--- a/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
+++ b/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
@@ -1745,7 +1745,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Genti.iOS.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1787,7 +1787,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Genti.iOS.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Genti_iOS/Genti_iOS/Data/Repositories/AuthRepositoryImpl.swift
+++ b/Genti_iOS/Genti_iOS/Data/Repositories/AuthRepositoryImpl.swift
@@ -38,7 +38,7 @@ final class AuthRepositoryImpl: AuthRepository {
     }
     
     func reissueToken(token: GentiTokenEntity) async throws -> GentiTokenEntity {
-        let dto: ReissueTokenDTO = try await requestService.fetchResponse(for: AuthRouter.reissueToken(token: token))
+        let dto: ReissueTokenDTO = try await requestService.fetchResponseNonRetry(for: AuthRouter.reissueToken(token: token))
         return GentiTokenEntity(accessToken: dto.accessToken, refreshToken: dto.refreshToken)
     }
     

--- a/Genti_iOS/Genti_iOS/Data/Services/RequestService.swift
+++ b/Genti_iOS/Genti_iOS/Data/Services/RequestService.swift
@@ -26,7 +26,7 @@ protocol RequestService {
 final class RequestServiceImpl: RequestService {
     func fetchResponseNonRetry<T: Decodable>(for endpoint: URLRequestConvertible) async throws -> T  {
         return try await withCheckedThrowingContinuation { continuation in
-            API.retrySession.request(endpoint)
+            API.nonRetrySession.request(endpoint)
                 .validate(statusCode: 200..<300)
                 .responseDecodable(of: APIResponse<T>.self) { res in
                     switch res.result {

--- a/Genti_iOS/Genti_iOS/Data/Services/RequestService.swift
+++ b/Genti_iOS/Genti_iOS/Data/Services/RequestService.swift
@@ -19,9 +19,38 @@ protocol RequestService {
     /// API요청 메서드(반환값이 필요없을때)
     /// - Parameter endpoint: endpoint
     func fetchResponse(for endpoint: URLRequestConvertible) async throws
+    
+    func fetchResponseNonRetry<T: Decodable>(for endpoint: URLRequestConvertible) async throws -> T
 }
 
 final class RequestServiceImpl: RequestService {
+    func fetchResponseNonRetry<T: Decodable>(for endpoint: URLRequestConvertible) async throws -> T  {
+        return try await withCheckedThrowingContinuation { continuation in
+            API.retrySession.request(endpoint)
+                .validate(statusCode: 200..<300)
+                .responseDecodable(of: APIResponse<T>.self) { res in
+                    switch res.result {
+                    case .success(let apiResponse):
+                        if apiResponse.success {
+                            guard let response = apiResponse.response else {
+                                continuation.resume(throwing: GentiError.serverError(code: "SERVER", message: "Success인데 response가 null입니다"))
+                                return
+                            }
+                            continuation.resume(returning: response)
+                        } else {
+                            continuation.resume(throwing: GentiError.serverError(code: "SERVER", message: "API가 200번대인데 내부 response의 success가 false입니다"))
+                        }
+                    case .failure(let error):
+                        if let data = res.data, let serverError = try? JSONDecoder().decode(APIResponse<Bool>.self, from: data), !serverError.success {
+                            continuation.resume(throwing: GentiError.serverError(code: serverError.errorCode, message: serverError.errorMessage))
+                        } else {
+                            continuation.resume(throwing: GentiError.clientError(code: "REQUESTERROR", message: "\(res.response?.statusCode ?? 0)\n\(error.localizedDescription)"))
+                        }
+                    }
+                }
+        }
+    }
+    
     func fetchResponse<T: Decodable>(for endpoint: URLRequestConvertible) async throws -> T {
         return try await withCheckedThrowingContinuation { continuation in
             API.session.request(endpoint)

--- a/Genti_iOS/Genti_iOS/Domain/Interfaces/UserDefaultsRepository.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Interfaces/UserDefaultsRepository.swift
@@ -20,7 +20,6 @@ protocol UserDefaultsRepository {
     func removeUserRole()
     func setLoginType(type: GentiSocialLoginType)
     func getLoginType() -> GentiSocialLoginType?
-    
 }
 
 extension UserDefaultsRepository {

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
@@ -15,6 +15,7 @@ enum AlertType {
     case reportComplete(action: AlertAction?)
     case logout(action: AlertAction?)
     case resign(action: AlertAction?)
+    case reportError(action: AlertAction?)
     case reportUnknownedError(error: Error, action: AlertAction?)
     case reportGentiError(error: GentiError, action: AlertAction?)
     case albumAuthorization
@@ -73,6 +74,8 @@ enum AlertType {
                          actions: [.init(title: "설정으로가기", action: { UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:]) { _ in
                 action!()
             } }), .init(title: "괜찮아요", style: .cancel, action: action)])
+        case .reportError(action: let action):
+            return .init(title: "일시적인 오류 발생", message: "앱을 종료 후 다시 시도해주세요\n로그인화면으로 이동합니다", actions: [.init(title: "확인", action: action)])
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogEventType.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/EventLog/Model/LogEventType.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum LogEventType {
+    case error(errorCode: String?, errorMessage: String?)
     case singIn(type: GentiSocialLoginType)
     case clickButton(page: PageType, buttonName: String)
     case viewInfoget
@@ -71,6 +72,8 @@ enum LogEventType {
             return "view_picdone"
         case .pushNotificationTap:
             return "click_push_notification"
+        case .error(errorCode: let errorCode, errorMessage: let errorMessage):
+            return "error"
         }
     }
     
@@ -82,6 +85,11 @@ enum LogEventType {
             return ["page_name": page.pageName, "button_name": buttonName]
         case .pushNotificationTap(let success):
             return ["push_type": success ? "creating_success" : "creating_fail"]
+        case .error(let errorCode, let errorMessage):
+            guard let errorCode = errorCode, let errorMessage = errorMessage else {
+                return ["errorCode": "nil입니다", "errorMessage": "nil입니다"]
+            }
+            return ["errorCode": errorCode, "errorMessage": errorMessage]
         default:
             return nil
         }

--- a/Genti_iOS/Genti_iOS/Instructure/NetworkBase/API.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/NetworkBase/API.swift
@@ -19,6 +19,6 @@ final class API {
     static let retrySession: Session = {
         let configuration = URLSessionConfiguration.af.default
         let apiLogger = APIEventLogger()
-        return Session(configuration: configuration, interceptor: APIRetryInterceptor(), eventMonitors: [apiLogger])
+        return Session(configuration: configuration, interceptor: nil, eventMonitors: [apiLogger])
     }()
 }

--- a/Genti_iOS/Genti_iOS/Instructure/NetworkBase/API.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/NetworkBase/API.swift
@@ -16,7 +16,7 @@ final class API {
         return Session(configuration: configuration, interceptor: APIEventInterceptor(), eventMonitors: [apiLogger])
     }()
     
-    static let retrySession: Session = {
+    static let nonRetrySession: Session = {
         let configuration = URLSessionConfiguration.af.default
         let apiLogger = APIEventLogger()
         return Session(configuration: configuration, interceptor: nil, eventMonitors: [apiLogger])

--- a/Genti_iOS/Genti_iOS/Instructure/NetworkBase/Interceptor/APIEventInterceptor.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/NetworkBase/Interceptor/APIEventInterceptor.swift
@@ -37,7 +37,7 @@ final class APIEventInterceptor: RequestInterceptor {
             return
         }
 
-        API.retrySession.request(AuthRouter.reissueToken(token: .init(accessToken: accessToken, refreshToken: refreshToken)))
+        API.nonRetrySession.request(AuthRouter.reissueToken(token: .init(accessToken: accessToken, refreshToken: refreshToken)))
             .responseData { response in
                 switch response.result {
                 case .success(let data):

--- a/Genti_iOS/Genti_iOS/Instructure/NetworkBase/Interceptor/APIEventInterceptor.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/NetworkBase/Interceptor/APIEventInterceptor.swift
@@ -44,7 +44,7 @@ final class APIEventInterceptor: RequestInterceptor {
                     do {
                         let result = try JSONDecoder().decode(APIResponse<ReissueTokenDTO>.self, from: data)
                         if !result.success {
-                            completion(.doNotRetryWithError(GentiError.tokenError(code: result.errorCode, message: result.errorMessage)))
+                            completion(.doNotRetryWithError(GentiError.tokenError(code: "reissue 성공했는데 success가 false임", message: result.errorMessage)))
                             return
                         }
                         guard let accessToken = result.response?.accessToken, let refreshToken = result.response?.refreshToken else {
@@ -53,7 +53,6 @@ final class APIEventInterceptor: RequestInterceptor {
                         }
                         self.userdefaultRepository.setAccessToken(token: accessToken)
                         self.userdefaultRepository.setRefreshToken(token: refreshToken)
-                        print(#fileID, #function, #line, "- 새로 받은 토큰으로 교체")
                         completion(.retry)
                         return
                     } catch {

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/View/FirstGeneratorView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/View/FirstGeneratorView.swift
@@ -188,7 +188,6 @@ struct FirstGeneratorView: View {
                     의상과 배경을 포함해서 설명해 주세요!  * 헤어스타일을 변경하는 기능은 준비 중이에요 * 너무 특정한 배경과 의상은 구현이 어려울 수 있어요 (반포 한강 공원, 나이키 티셔츠 등)
                     """)
                 .withFont(font: .PretendardType.small.value, color: .gray7, minimumScaleFactor: 0.5)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 11)
                 .onTapGesture {

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/ThirdGeneratorViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/ViewModel/ThirdGeneratorViewModel.swift
@@ -70,10 +70,12 @@ final class ThirdGeneratorViewModel: ViewModel, GetImageFromImagePicker {
         } catch(let error) {
             state.isLoading = false
             guard let error = error as? GentiError else {
-                state.showAlert = .reportUnknownedError(error: error, action: nil)
+                EventLogManager.shared.logEvent(.error(errorCode: "Unknowned", errorMessage: error.localizedDescription))
+                state.showAlert = .reportError(action: {self.router.popToRoot()})
                 return
             }
-            state.showAlert = .reportGentiError(error: error, action: nil)
+            EventLogManager.shared.logEvent(.error(errorCode: error.code, errorMessage: error.message))
+            state.showAlert = .reportError(action: {self.router.popToRoot()})
         }
     }
     

--- a/Genti_iOS/Genti_iOS/Presentation/Home/ViewModel/MainFeedViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Home/ViewModel/MainFeedViewModel.swift
@@ -71,10 +71,12 @@ final class MainFeedViewModel: ViewModel {
             state.feeds = try await feedRepository.fetchFeeds()
         } catch(let error) {
             guard let error = error as? GentiError else {
-                state.showAlert = .reportUnknownedError(error: error, action: nil)
+                EventLogManager.shared.logEvent(.error(errorCode: "Unknowned", errorMessage: error.localizedDescription))
+                state.showAlert = .reportError(action: {self.router.popToRoot()})
                 return
             }
-            state.showAlert = .reportGentiError(error: error, action: nil)
+            EventLogManager.shared.logEvent(.error(errorCode: error.code, errorMessage: error.message))
+            state.showAlert = .reportError(action: {self.router.popToRoot()})
         }
     }
 

--- a/Genti_iOS/Genti_iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -71,9 +71,11 @@ final class ProfileViewModel: ViewModel {
     
     private func handleError(_ error: Error) {
         guard let error = error as? GentiError else {
-            state.showAlert = .reportUnknownedError(error: error, action: nil)
+            EventLogManager.shared.logEvent(.error(errorCode: "Unknowned", errorMessage: error.localizedDescription))
+            state.showAlert = .reportError(action: {self.router.popToRoot()})
             return
         }
-        state.showAlert = .reportGentiError(error: error, action: nil)
+        EventLogManager.shared.logEvent(.error(errorCode: error.code, errorMessage: error.message))
+        state.showAlert = .reportError(action: {self.router.popToRoot()})
     }
 }

--- a/Genti_iOS/Genti_iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -86,9 +86,11 @@ final class SettingViewModel: NSObject, ViewModel {
     private func handleError(_ error: Error) {
         state.isLoading = false
         guard let error = error as? GentiError else {
-            state.showAlert = .reportUnknownedError(error: error, action: nil)
+            EventLogManager.shared.logEvent(.error(errorCode: "Unknowned", errorMessage: error.localizedDescription))
+            state.showAlert = .reportError(action: {self.router.popToRoot()})
             return
         }
-        state.showAlert = .reportGentiError(error: error, action: nil)
+        EventLogManager.shared.logEvent(.error(errorCode: error.code, errorMessage: error.message))
+        state.showAlert = .reportError(action: {self.router.popToRoot()})
     }
 }

--- a/Genti_iOS/Genti_iOS/Presentation/TabView/ViewModel/TabViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/TabView/ViewModel/TabViewModel.swift
@@ -125,9 +125,11 @@ final class TabViewModel: ViewModel {
     private func handleError(_ error: Error) {
         state.isLoading = false
         guard let error = error as? GentiError else {
-            state.showAlert = .reportUnknownedError(error: error, action: nil)
+            EventLogManager.shared.logEvent(.error(errorCode: "Unknowned", errorMessage: error.localizedDescription))
+            state.showAlert = .reportError(action: {self.router.popToRoot()})
             return
         }
-        state.showAlert = .reportGentiError(error: error, action: nil)
+        EventLogManager.shared.logEvent(.error(errorCode: error.code, errorMessage: error.message))
+        state.showAlert = .reportError(action: {self.router.popToRoot()})
     }
 }


### PR DESCRIPTION
## [#83] RELEASE : 1.1.1버전배포

## 🌱 작업한 내용
- error가 발생했을때 loginview로 이동하며 유저에게 "일시적인오류"라는 알림을 띄우는 방식으로 변경
- 실제 발생한 error는 amplitude에 누적시킬수있게 구현
- reissue의 경우에 header에 accesstoken을 담지 않으며 retry를 시도하지 않는 방식으로 수정

## 🌱 PR Point
### 오류처리
- 1.0.x버전에서는 실제 서버에서 오는 오류코드와 메세지를 알림의 title과 body에 넣었는데 운영단계에선 유저에게 보여주지 않아도될 정보라고 판단. 일시적인오류라는 공통된 알림으로 보내며 확인버튼을 누르면 로그인뷰로 넘어가서(예상하건데 대부분의 오류는 토큰만류일것이기때문에 새로로그인하면 문제가 없을것) 재로그인을 유도함

### 토큰갱신API호출
- 서버측에서 spring의 경우엔 header가 필요없는데 header가 담겨져있는 경우 문제가 발생할수도있다는 이야기를 듣게됨
- 토큰갱신의 경우엔 body에 accesstoken과 refreshtoken을 담아주기 때문에 header에 정보를 담아줄필요가없음
- 하지만 기존에는 모든 API의 경우 같은 interceptor를 가지는 session을 사용하기에 header에 accesstoken을 담아왔음. 기존에는 큰문제가 없었는데 문제가 발생할수있다고 함
- 또한 reissue의 경우에도 문제가 생겼을때 retry하는 interceptor를 그대로 사용하기에 reissue를 실패하면 reissue를 한번더 실행하는 중복 API호출이 발생하게됨
- 이부분을 해결하기위해 interceptor가 필요없는(당장은 토큰reissue API에서만 쓰임) nonRetrySession을 추가함
```swift
static let nonRetrySession: Session = {
    let configuration = URLSessionConfiguration.af.default
    let apiLogger = APIEventLogger()
    return Session(configuration: configuration, interceptor: nil, eventMonitors: [apiLogger])
}()
```
- 기존에 한번 문제가 발생했던 부분이 retry에서 retry를 하는 interceptor를 사용하는 바람에 401오류가 발생했을때 재귀적으로 API를 호출해서 무한API호출하는 문제가 발생했었음
- 토큰갱신의 경우엔 해당 session을 사용하면 API문서대로 header도 비어있고 실패시 retry를 하지 않을수있음

## 📮 관련 이슈

- Resolved: #83 
