### PR TITLE
[REFACTOR] 이미지로딩 구조 수정(#86)

### DIFF
--- a/Genti_iOS/Genti_iOS/Application/AppDelegate.swift
+++ b/Genti_iOS/Genti_iOS/Application/AppDelegate.swift
@@ -56,7 +56,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 extension AppDelegate: UNUserNotificationCenterDelegate {
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-        
+//        let userInfo = response.notification.request.content.userInfo
         NotificationCenter.default.post(
             name: NSNotification.Name(rawValue: "PushNotificationReceived"),
             object: nil,

--- a/Genti_iOS/Genti_iOS/Application/MainRoute.swift
+++ b/Genti_iOS/Genti_iOS/Application/MainRoute.swift
@@ -14,7 +14,7 @@ enum MainRoute: Route {
     case onboarding
     case mainTab
     case setting
-    case photoDetailWithShare(image: UIImage)
+    case photoDetailWithShare(imageUrl: String)
     case firstGen
     case secondGen(data: RequestImageData)
     case thirdGen(data: RequestImageData)
@@ -22,7 +22,7 @@ enum MainRoute: Route {
     case waiting
     case imagePicker(limitCount: Int, viewModel: GetImageFromImagePicker)
     case webView(url: String)
-    case photoDetail(image: UIImage)
+    case photoDetail(imageUrl: String)
     case completeMakePhoto(photoInfo: CompletedPhotoEntity)
 
     
@@ -35,8 +35,8 @@ enum MainRoute: Route {
             GentiTabView(viewModel: TabViewModel(tabViewUseCase: TabViewUseCaseImpl(userRepository: UserRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl()), router: router))
         case .setting:
             SettingView(viewModel: SettingViewModel(router: router))
-        case .photoDetailWithShare(let image):
-            PhotoDetailWithShareView(viewModel: PhotoDetailViewModel(photoDetailUseCase: PhotoDetailUseCaseImpl(imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl()), router: router, image: image))
+        case .photoDetailWithShare(let imageUrl):
+            PhotoDetailWithShareView(viewModel: PhotoDetailViewModel(photoDetailUseCase: PhotoDetailUseCaseImpl(imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl()), router: router, imageUrl: imageUrl))
         case .firstGen:
             RoutingView(router) { FirstGeneratorView(viewModel: FirstGeneratorViewModel(router: $0)) }
         case .secondGen(let data):
@@ -49,8 +49,8 @@ enum MainRoute: Route {
             GenerateRequestCompleteView(router: router)
         case .webView(url: let url):
             GentiWebView(router: router, urlString: url)
-        case .photoDetail(let image):
-            PhotoDetailView(viewModel: PhotoDetailViewModel(photoDetailUseCase: PhotoDetailUseCaseImpl(imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl()), router: router, image: image))
+        case .photoDetail(let imageUrl):
+            PhotoDetailView(viewModel: PhotoDetailViewModel(photoDetailUseCase: PhotoDetailUseCaseImpl(imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl()), router: router, imageUrl: imageUrl))
         case .completeMakePhoto(let photoInfo):
             RoutingView(router) { CompletedPhotoView(viewModel: CompletedPhotoViewModel(photoInfo: photoInfo, router: $0, completedPhotoUseCase: CompletedPhotoUseCaseImpl(imageRepository: ImageRepositoryImpl(), hapticRepository: HapticRepositoryImpl(), userRepository: UserRepositoryImpl(requestService: RequestServiceImpl())))) }
         case .onboarding:

--- a/Genti_iOS/Genti_iOS/Data/DTO/ExampleWithPictureFindResponseDTO.swift
+++ b/Genti_iOS/Genti_iOS/Data/DTO/ExampleWithPictureFindResponseDTO.swift
@@ -20,7 +20,7 @@ struct ExampleWithPictureFindResponseDTO: Codable {
 
 extension ExampleWithPictureFindResponseDTO {
     var toEntity: FeedEntity {
-        return .init(id: self.picture.id, mainImage: self.picture.url, description: self.prompt, ratio: self.ratio)
+        return .init(id: self.picture.id, imageUrl: self.picture.url, description: self.prompt, ratio: self.ratio)
     }
     
     var ratio: PhotoRatio {

--- a/Genti_iOS/Genti_iOS/Data/Repositories/ImageRepositoryImpl.swift
+++ b/Genti_iOS/Genti_iOS/Data/Repositories/ImageRepositoryImpl.swift
@@ -12,15 +12,6 @@ import SDWebImageSwiftUI
 final class ImageRepositoryImpl: NSObject, ImageRepository {
     
     private var continuation: CheckedContinuation<Bool, Never>?
-    
-    func load(from urlString: String) async -> UIImage? {
-        return await withCheckedContinuation { continuation in
-            guard let url = URL(string: urlString) else { return continuation.resume(returning: nil) }
-            SDWebImageManager.shared.loadImage(with: url, options: [], progress: nil) { (image, _, _, _, _, _) in
-                continuation.resume(returning: image)
-                }
-        }
-    }
 
     func writeToPhotoAlbum(image: UIImage?) async -> Bool {
         await withCheckedContinuation { continuation in

--- a/Genti_iOS/Genti_iOS/Domain/Entities/FeedEntity.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Entities/FeedEntity.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct FeedEntity: Identifiable {
     var id: Int
-    let mainImage: String
+    let imageUrl: String
     let description: String
     var ratio: PhotoRatio
 }

--- a/Genti_iOS/Genti_iOS/Domain/Interfaces/ImageRepository.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Interfaces/ImageRepository.swift
@@ -8,6 +8,5 @@
 import UIKit
 
 protocol ImageRepository {
-    func load(from urlString: String) async -> UIImage?
     func writeToPhotoAlbum(image: UIImage?) async -> Bool
 }

--- a/Genti_iOS/Genti_iOS/Domain/UseCases/CompletedPhotoUseCase.swift
+++ b/Genti_iOS/Genti_iOS/Domain/UseCases/CompletedPhotoUseCase.swift
@@ -9,7 +9,6 @@ import UIKit
 
 protocol CompletedPhotoUseCase {
     func downloadImage(to uiImage: UIImage?) async -> Bool
-    func loadImage(url: String) async -> UIImage?
     func reportPhoto(responseId: Int, content: String) async throws
 }
 
@@ -31,10 +30,6 @@ final class CompletedPhotoUseCaseImpl: CompletedPhotoUseCase {
         let writeSuccess = await imageRepository.writeToPhotoAlbum(image: uiImage)
         hapticRepository.notification(type: writeSuccess ? .success : .error)
         return writeSuccess
-    }
-    
-    func loadImage(url: String) async -> UIImage? {
-        return await imageRepository.load(from: url)
     }
     
     func reportPhoto(responseId: Int, content: String) async throws {

--- a/Genti_iOS/Genti_iOS/Domain/UseCases/ProfileUseCase.swift
+++ b/Genti_iOS/Genti_iOS/Domain/UseCases/ProfileUseCase.swift
@@ -11,7 +11,6 @@ import UIKit
 protocol ProfileUseCase {
     func fetchInitalUserInfo() async throws -> UserInfoEntity
     func getCompletedPhotos() async throws -> [MyImagesEntitiy]
-    func showPhotoDetail(from urlString: String) async -> UIImage?
 }
 
 final class ProfileUseCaseImpl: ProfileUseCase {
@@ -32,10 +31,6 @@ final class ProfileUseCaseImpl: ProfileUseCase {
 
     func getCompletedPhotos() async throws -> [MyImagesEntitiy] {
         return try await userRepository.fetchPhotos()
-    }
-    
-    func showPhotoDetail(from urlString: String) async -> UIImage? {
-        return await imageRepository.load(from: urlString)
     }
 }
 

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/CompletedPhotoView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/CompletedPhotoView.swift
@@ -70,6 +70,9 @@ struct CompletedPhotoView: View {
                 }
             }
         }
+        .onAppear {
+            self.viewModel.sendAction(.viewWillAppear)
+        }
         .addCustomPopup(isPresented: $viewModel.state.showRatingView, popupType: .rating(viewModel.photoInfo))
         .onReceive(NotificationCenter.default.publisher(for: .init("ratingCompleted"))) { _ in
             self.viewModel.sendAction(.ratingActionIsDone)

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/GaroImageContentView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/GaroImageContentView.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+import SDWebImageSwiftUI
+import Lottie
+
 struct GaroImageContentView: View {
     
     @Bindable var viewModel: CompletedPhotoViewModel
@@ -43,19 +46,24 @@ struct GaroImageContentView: View {
             Spacer()
                 .frame(height: 16)
             
-            
-            viewModel.getImage
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 212)
-                .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap) }
-                .cornerRadiusWithBorder(style: LinearGradient.borderGreen, radius: 15, lineWidth: 2)
-                .onTapGesture {
-                    self.viewModel.sendAction(.imageTap)
-                }
-                .onAppear {
-                    self.viewModel.sendAction(.viewWillAppear)
-                }
+            WebImage(url: URL(string: viewModel.state.imageUrl)) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 212)
+                    .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap) }
+                    .cornerRadiusWithBorder(style: LinearGradient.borderGreen, radius: 15, lineWidth: 2)
+                    .onTapGesture {
+                        self.viewModel.sendAction(.imageTap)
+                    }
+            } placeholder: {
+                LottieView(type: .imageLoading)
+                    .looping()
+                    .frame(width: 80, height: 80)
+            }
+            .onSuccess { image, _, _ in
+                self.viewModel.sendAction(.imageLoad(image))
+            }
             
             Spacer().frame(height: 18)
             

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/SeroImageContentView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/SeroImageContentView.swift
@@ -7,6 +7,9 @@
 
 import SwiftUI
 
+import SDWebImageSwiftUI
+import Lottie
+
 struct SeroImageContentView: View {
     @Bindable var viewModel: CompletedPhotoViewModel
     
@@ -37,20 +40,25 @@ struct SeroImageContentView: View {
             Spacer()
                 .frame(height: 16)
             
-            viewModel.getImage
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(height: 360)
-                .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap) }
-                .cornerRadiusWithBorder(style: LinearGradient.borderGreen, radius: 15, lineWidth: 2)
-                .onTapGesture {
-                    print(#fileID, #function, #line, "- imagetap")
-                    self.viewModel.sendAction(.imageTap)
-                }
-                .onAppear {
-                    self.viewModel.sendAction(.viewWillAppear)
-                }
-            
+            WebImage(url: URL(string: viewModel.state.imageUrl)) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: 360)
+                    .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap) }
+                    .cornerRadiusWithBorder(style: LinearGradient.borderGreen, radius: 15, lineWidth: 2)
+                    .onTapGesture {
+                        print(#fileID, #function, #line, "- imagetap")
+                        self.viewModel.sendAction(.imageTap)
+                    }
+            } placeholder: {
+                LottieView(type: .imageLoading)
+                    .looping()
+                    .frame(width: 80, height: 80)
+            }
+            .onSuccess { image, _, _ in
+                self.viewModel.sendAction(.imageLoad(image))
+            }
             
             Spacer()
                 .frame(height: 18)
@@ -60,7 +68,6 @@ struct SeroImageContentView: View {
         }
         .frame(height: 640)
         .frame(maxWidth: .infinity)
-        
         .background(alignment: .top) {
             Rectangle()
                 .fill(.backgroundWhite)

--- a/Genti_iOS/Genti_iOS/Presentation/Home/View/FeedComponent.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Home/View/FeedComponent.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FeedComponent: View {
     
-    var mainImage: String
+    var imageUrl: String
     var description: String
     var ratio: PhotoRatio
     
@@ -26,7 +26,7 @@ struct FeedComponent: View {
     }
     
     private func mainImageView() -> some View {
-        ImageLoaderView(urlString: mainImage, ratio: ratio)
+        ImageLoaderView(urlString: imageUrl, ratio: ratio)
             .cornerRadiusWithBorder(style: Color.gentiGreen, radius: 15, lineWidth: 1)
     }
     private func photoDescriptionView() -> some View {

--- a/Genti_iOS/Genti_iOS/Presentation/Home/View/MainFeedView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Home/View/MainFeedView.swift
@@ -41,7 +41,7 @@ struct MainFeedView: View {
     private func feedsView() -> some View {
         LazyVStack(spacing: 0) {
             ForEach(viewModel.state.feeds, id: \.id) { feed in
-                FeedComponent(mainImage: feed.mainImage, description: feed.description, ratio: feed.ratio)
+                FeedComponent(imageUrl: feed.imageUrl, description: feed.description, ratio: feed.ratio)
             }
         }
         .readingFrame { frame in

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailView.swift
@@ -7,36 +7,34 @@
 
 import SwiftUI
 
+import SDWebImageSwiftUI
+
 struct PhotoDetailView: View {
 
     @State var viewModel: PhotoDetailViewModel
     
     var body: some View {
-        Image(uiImage: viewModel.state.image)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .overlay(alignment: .bottomTrailing) {
-                Image("Download")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 44, height: 44)
-                    .padding(.trailing, 10)
-                    .padding(.bottom, 10)
-                    .asButton {
-                        self.viewModel.sendAction(.downloadButtonTap(from: .detail))
-                    }
-            }
-            .padding(.horizontal, 28)
-            .addXmark(top: 3, trailing: 20) { viewModel.sendAction(.xmarkTap) }
-            .customToast(toastType: $viewModel.state.showToast)
-            .presentationBackground {
-                BlurView(style: .systemUltraThinMaterialDark)
-                    .onTapGesture {
-                        viewModel.sendAction(.backgroundTap)
-                    }
-            }
-
         
+        WebImage(url: URL(string: viewModel.state.imageUrl)) { image in
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap(from: .detail)) }
+        } placeholder: {
+            Image(uiImage: UIImage(resource: .camera))
+        }
+        .onSuccess { image, _, _ in
+            self.viewModel.sendAction(.imageLoad(image))
+        }
+        .padding(.horizontal, 28)
+        .addXmark(top: 3, trailing: 20) { viewModel.sendAction(.xmarkTap) }
+        .customToast(toastType: $viewModel.state.showToast)
+        .presentationBackground {
+            BlurView(style: .systemUltraThinMaterialDark)
+                .onTapGesture {
+                    viewModel.sendAction(.backgroundTap)
+                }
+        }
     }
 }
 

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailWithShareView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/View/PhotoDetailWithShareView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import SDWebImageSwiftUI
+
 struct PhotoDetailWithShareView: View {
     @State var viewModel: PhotoDetailViewModel
 
@@ -16,15 +18,21 @@ struct PhotoDetailWithShareView: View {
                 .fill(.clear)
                 .aspectRatio(1/1.5, contentMode: .fit)
                 .overlay(alignment: .center) {
-                    Image(uiImage: viewModel.state.image)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .addDownloadButton {
-                            viewModel.sendAction(.downloadButtonTap(from: .detailWithShare)) }
+                    WebImage(url: URL(string: viewModel.state.imageUrl)) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap(from: .detailWithShare)) }
+                    } placeholder: {
+                        Image(uiImage: UIImage(resource: .camera))
+                    }
+                    .onSuccess { image, _, _ in
+                        self.viewModel.sendAction(.imageLoad(image))
+                    }
                 }
                 .padding(.horizontal, 30)
             
-            ShareLink(item: Image(uiImage: viewModel.state.image), preview: .init("내 사진", image: Image(uiImage: viewModel.state.image))) {
+            ShareLink(item: viewModel.getImage, preview: .init("내 사진", image: viewModel.getImage)) {
                 Text("공유하기")
                     .shareStyle()
             }

--- a/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/PhotoDetail/ViewModel/PhotoDetailViewModel.swift
@@ -16,7 +16,8 @@ final class PhotoDetailViewModel: ViewModel {
     var router: Router<MainRoute>
     
     struct State {
-        var image: UIImage
+        var imageUrl: String
+        var image: UIImage?
         var showToast: ToastType? = nil
     }
     enum Input {
@@ -24,14 +25,15 @@ final class PhotoDetailViewModel: ViewModel {
         case xmarkTap
         case backgroundTap
         case shareButtonTap
+        case imageLoad(UIImage)
     }
     
     var state: State
     
-    init(photoDetailUseCase: PhotoDetailUseCase, router: Router<MainRoute>, image: UIImage) {
+    init(photoDetailUseCase: PhotoDetailUseCase, router: Router<MainRoute>, imageUrl: String) {
         self.photoDetailUseCase = photoDetailUseCase
         self.router = router
-        self.state = .init(image: image)
+        self.state = .init(imageUrl: imageUrl)
     }
     
     func sendAction(_ input: Input) {
@@ -43,18 +45,28 @@ final class PhotoDetailViewModel: ViewModel {
         case .shareButtonTap:
             EventLogManager.shared.logEvent(.clickButton(page: .profile, buttonName: "picshare"))
             EventLogManager.shared.addUserPropertyCount(to: .shareButtonTap)
+        case .imageLoad(let image):
+            self.state.image = image
         }
     }
     
     @MainActor
     func download(type: DetailViewType) async {
         do {
-            if await photoDetailUseCase.downloadImage(to: state.image) {
+            guard let image = state.image else { return }
+            if await photoDetailUseCase.downloadImage(to: image) {
                 EventLogManager.shared.logEvent(.clickButton(page: type.initalPage, buttonName: "picdownload"))
                 state.showToast = .success
             } else {
                 state.showToast = .failure
             }
         }
+    }
+    
+    var getImage: Image {
+        if let image = self.state.image {
+            return Image(uiImage: image)
+        }
+        return Image(uiImage: UIImage(resource: .camera))
     }
 }

--- a/Genti_iOS/Genti_iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Profile/ViewModel/ProfileViewModel.swift
@@ -37,7 +37,7 @@ final class ProfileViewModel: ViewModel {
         switch input {
         case .imageTap(let url):
             EventLogManager.shared.logEvent(.enlargePhoto)
-            Task { await showMyImage(url: url) }
+            router.routeTo(.photoDetailWithShare(imageUrl: url))
         case .gearButtonTap:
             router.routeTo(.setting)
         case .reload, .viewWillAppear:
@@ -52,14 +52,6 @@ final class ProfileViewModel: ViewModel {
             setState(entity)
         } catch(let error) {
             handleError(error)
-        }
-    }
-    
-    @MainActor
-    func showMyImage(url: String) async {
-        do {
-            guard let image = await profileUseCase.showPhotoDetail(from: url) else { return }
-            router.routeTo(.photoDetailWithShare(image: image))
         }
     }
     

--- a/Genti_iOS/Genti_iOS/Presentation/TabView/View/GentiTabView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/TabView/View/GentiTabView.swift
@@ -34,6 +34,9 @@ struct GentiTabView: View {
         .onNotificationRecieved(name: Notification.Name(rawValue: "PushNotificationReceived")) { _ in
             self.viewModel.sendAction(.pushReceived)
         }
+        .onNotificationRecieved(name: Notification.Name(rawValue: "openChat")) { _ in
+            self.viewModel.sendAction(.openChat)
+        }
         .ignoresSafeArea(.keyboard)
         .toolbar(.hidden, for: .navigationBar)
     }

--- a/Genti_iOS/Genti_iOS/Presentation/TabView/ViewModel/TabViewModel.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/TabView/ViewModel/TabViewModel.swift
@@ -27,6 +27,7 @@ final class TabViewModel: ViewModel {
         case cameraIconTap
         case viewWillAppear
         case pushReceived
+        case openChat
     }
     func sendAction(_ input: Input) {
         switch input {
@@ -44,6 +45,10 @@ final class TabViewModel: ViewModel {
         case .pushReceived:
             // 유저가 푸시를 누른 경우
             Task { await handleUserStateFromPush() }
+        case .openChat:
+            self.router.dismissSheet {
+                self.router.routeTo(.firstGen)
+            }
         }
     }
     


### PR DESCRIPTION
## [#86] REFACTOR : 이미지로딩

## 🌱 작업한 내용
## 지나고 보니 이미지로딩쪽이 완전 잘못된 구조인걸 깨달음
- 현재 genti프로젝트는 imageload를 위한 library로 sdwebimage를 사용하고 있음
- 앱특성상 서버에서 이미지의 url을 받아와서 이미지를 load해야하는 로직이 거의 모든뷰에 존재함
- 하지만 추가적으로 image의 download및 share기능을 위해 이미지 자체를 url뿐아니라 image형태로 가지고있어야하는 뷰들도 많음
```swift
WebImage(url: URL(string: viewModel.state.imageUrl)) { image in
    ...생략...
} placeholder: {
    ...생략...
}
.onSuccess { image, _, _ in
    self.viewModel.sendAction(.imageLoad(image))
}
```
- sdwebimage에서는 위와같은 코드로 image를 load할수있는데 이미지 로드를 성공하면 uiimage를 반환받아서 실제 객체로 들고있을수있는 기능이있다는걸 알게됨
---
### 기존방식(틀린방식)
1. 이미지 url을 받는다
2. viewwillappear가 호출되면 url을 가지고 imagerepository에서 uiimage를 반환받는다
3. 그렇게 받은 uiimage를 state의 image변수에 할당해준다
4. 할당한다면 이걸 UI가 `@observable`로 감지해 UI에 image를 띄워준다

- url을 가지고 image를 띄워주더라도 이미지 다운로드 혹은 공유에 uiimage객체가 필요했기에 처음부터 uiimage형태로 변환후 ui에 띄워주는 방식을 선택했습니다
- 하지만 이렇게했을때 state에 변수를 할당할때 mainthread가 아니면 업데이트를 감지하지못하는 side-effect나 단순히 url을 받아서 이미지를 띄워준다가 아닌 url을 받아서 uiimage를 만들어서 띄워준다가 되기때문에 한 depth가 더 늘어나는 문제가 있고
- webimage에는 placeholder가 있지만 uiimage를 만들어서 ui에 띄워준다면 url을 image로 바꿔서 state에 할당해주기전까지는 uiimage가 nil인상태이기때문에 ui에서도 nil일때의 처리를 해줘야하는 불편함이 존재합니다

> [!WARNING]  
> 특히 mainthread문제임을 확신하지못했을때 url을 넘겨주는게아닌 이전뷰에서 url을 image로 변환해서 다음 view로 넘겨주는 방식으로 구현하기도 하는등 로직이 복잡해지고 다양한 side-effect가 발생할수있는 가능성을 고려하지 못했습니다

### 변경후방식
- uiimage를 넘기는방식이 아닌 url을 넘기고 viewmodel의 init에 state의 url에 해당 변수를 넘겨주면 `webimage에는 placeholder가 있지만 uiimage를 만들어서 ui에 띄워준다면 url을 image로 바꿔서 state에 할당해주기전까지는 uiimage가 nil인상태이기때문에 ui에서도 nil일때의 처리를 해줘야하는 불편함이 존재합니다`를 예방할수있고 UI에서는 해당 url로 webimage로 띄워주며 placeholder를 사용해 loading을 안정적으로 처리할수있습니다
- onsuccess에서의 image객체를 viewmodel의 state에 넘겨줘서 download나 share시 해당 image객체를 사용할 수 있게 했습니다
- imagerepository에서 url을 image로 반환해주는 로직이 필요없어 제거할수있습니다

## 📮 관련 이슈

- Resolved: #86 
