### PR TITLE
[FIX] SE기기 대응 및 강제업데이트 기능 추가(#88)

### DIFF
--- a/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
+++ b/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
@@ -128,6 +128,8 @@
 		C049679A2C6480720097C732 /* CompletedPhotoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04967992C6480720097C732 /* CompletedPhotoUseCase.swift */; };
 		C04967CD2C6496FA0097C732 /* UserInfoEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04967CC2C6496FA0097C732 /* UserInfoEntity.swift */; };
 		C04967D32C64982A0097C732 /* UserRequestCancelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C04967D22C64982A0097C732 /* UserRequestCancelState.swift */; };
+		C06F28F62C92D01C00A69575 /* AppStoreCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06F28F52C92D01C00A69575 /* AppStoreCheck.swift */; };
+		C06F28F82C92FE4800A69575 /* UIScreen+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06F28F72C92FE4800A69575 /* UIScreen+Ext.swift */; };
 		C088F2D42C26564A00F92320 /* PHAssetImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088F2D32C26564A00F92320 /* PHAssetImageRepository.swift */; };
 		C088F2D62C26567500F92320 /* PHAssetImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088F2D52C26567500F92320 /* PHAssetImageService.swift */; };
 		C088F2DA2C2656BA00F92320 /* PHAssetImageRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C088F2D92C2656BA00F92320 /* PHAssetImageRepositoryImpl.swift */; };
@@ -337,6 +339,8 @@
 		C04967992C6480720097C732 /* CompletedPhotoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletedPhotoUseCase.swift; sourceTree = "<group>"; };
 		C04967CC2C6496FA0097C732 /* UserInfoEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoEntity.swift; sourceTree = "<group>"; };
 		C04967D22C64982A0097C732 /* UserRequestCancelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRequestCancelState.swift; sourceTree = "<group>"; };
+		C06F28F52C92D01C00A69575 /* AppStoreCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreCheck.swift; sourceTree = "<group>"; };
+		C06F28F72C92FE4800A69575 /* UIScreen+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Ext.swift"; sourceTree = "<group>"; };
 		C088F2D32C26564A00F92320 /* PHAssetImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHAssetImageRepository.swift; sourceTree = "<group>"; };
 		C088F2D52C26567500F92320 /* PHAssetImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHAssetImageService.swift; sourceTree = "<group>"; };
 		C088F2D92C2656BA00F92320 /* PHAssetImageRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHAssetImageRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -549,6 +553,7 @@
 				C0113D882C3BED0400071BF6 /* LinearGradient+Ext.swift */,
 				C08BB5B92C3E8B3E00D4CFA9 /* LottieView+Ext.swift */,
 				C048A9052C51BA1500026C80 /* Int+Ext.swift */,
+				C06F28F72C92FE4800A69575 /* UIScreen+Ext.swift */,
 			);
 			path = Extentions;
 			sourceTree = "<group>";
@@ -1193,6 +1198,7 @@
 			isa = PBXGroup;
 			children = (
 				C0B192612C7857F200D198A2 /* NotificationPermissionCheck.swift */,
+				C06F28F52C92D01C00A69575 /* AppStoreCheck.swift */,
 			);
 			path = SharedStruct;
 			sourceTree = "<group>";
@@ -1423,6 +1429,7 @@
 				C017C49C2C1C3AA3009924C9 /* RequestService.swift in Sources */,
 				C0A7C64C2C68533400FAA7F1 /* GentiBorderButton.swift in Sources */,
 				C0D74A462C1EA6B500A45371 /* Route.swift in Sources */,
+				C06F28F62C92D01C00A69575 /* AppStoreCheck.swift in Sources */,
 				C017C4852C1C3AA3009924C9 /* FirstGeneratorView.swift in Sources */,
 				C088F2D62C26567500F92320 /* PHAssetImageService.swift in Sources */,
 				C0113D6F2C3A21B100071BF6 /* CompletedPhotoViewViewModel.swift in Sources */,
@@ -1516,6 +1523,7 @@
 				C0113D862C3BEAA400071BF6 /* AddXmarkModifier.swift in Sources */,
 				C02843552C314C1E00B84566 /* FeedRouter.swift in Sources */,
 				C0113D902C3D3A0900071BF6 /* OnboardingStep.swift in Sources */,
+				C06F28F82C92FE4800A69575 /* UIScreen+Ext.swift in Sources */,
 				C049674D2C5C87FE0097C732 /* TabViewUseCase.swift in Sources */,
 				C0ADA6012C851C6C00A583B8 /* ImagePickerViewModel.swift in Sources */,
 				C0A7C6482C68415D00FAA7F1 /* RequestWaitingView.swift in Sources */,

--- a/Genti_iOS/Genti_iOS/Application/GentiApp.swift
+++ b/Genti_iOS/Genti_iOS/Application/GentiApp.swift
@@ -11,7 +11,7 @@ struct GentiApp: View {
 
     var body: some View {
         RoutingView(Router<MainRoute>()) { router in
-            SplashView(splashViewModel: SplashViewModel(router: router, splashUseCase: SplashUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl())))
+            SplashView(viewModel: SplashViewModel(router: router, splashUseCase: SplashUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl())))
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Data/Repositories/UserDefaultsRepositoryImpl.swift
+++ b/Genti_iOS/Genti_iOS/Data/Repositories/UserDefaultsRepositoryImpl.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct UserDefaultsRepositoryImpl: UserDefaultsRepository {
+    
     func setLoginType(type: GentiSocialLoginType) {
         self.set(to: type.rawValue, forKey: .loginType)
     }

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
@@ -22,6 +22,7 @@ enum AlertType {
     case photoCompleted(action: AlertAction?)
     case photoRequestCanceled(action: AlertAction?)
     case pushAuthorization(action: AlertAction?)
+    case update(action: AlertAction?)
     
     var data: Alert {
         switch self {
@@ -76,6 +77,8 @@ enum AlertType {
             } }), .init(title: "괜찮아요", style: .cancel, action: action)])
         case .reportError(action: let action):
             return .init(title: "일시적인 오류 발생", message: "앱을 종료 후 다시 시도해주세요\n로그인화면으로 이동합니다", actions: [.init(title: "확인", action: action)])
+        case .update(action: let action):
+            return .init(title: "업데이트 알림", message: "더 나은 서비스를 위해 필요한 업데이트가 있습니다!\n업데이트해주시겠어요?", actions: [.init(title: "업데이트하러 가기", action: action)])
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Instructure/Extentions/UIScreen+Ext.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/Extentions/UIScreen+Ext.swift
@@ -1,0 +1,12 @@
+//
+//  UIScreen+Ext.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 9/12/24.
+//
+
+import UIKit
+
+extension UIScreen {
+    static var isWiderThan375pt: Bool { UIScreen.main.bounds.width > 375.0 }
+}

--- a/Genti_iOS/Genti_iOS/Instructure/SharedStruct/AppStoreCheck.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/SharedStruct/AppStoreCheck.swift
@@ -1,0 +1,40 @@
+//
+//  AppStoreCheck.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 9/12/24.
+//
+
+import UIKit
+
+struct AppStoreCheck {
+    private static let appID = "6596739805"
+    static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    static let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    static let appStoreOpenUrlString = "itms-apps://itunes.apple.com/app/apple-store/\(appID)"
+
+    func latestVersion(completion: @escaping (String?) -> Void) {
+        guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(Self.appID)&country=kr") else {
+            completion(nil)
+            return
+        }
+        
+        URLSession.shared.dataTask(with: url) { (data, response, error) in
+            guard let data = data, error == nil,
+                  let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any],
+                  let results = json["results"] as? [[String: Any]],
+                  let appStoreVersion = results[0]["version"] as? String else {
+                completion(nil)
+                return
+            }       
+            completion(appStoreVersion)
+        }.resume()
+    }
+
+    func openAppStore() {
+        guard let url = URL(string: AppStoreCheck.appStoreOpenUrlString) else { return }
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+}

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/GaroImageContentView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/GaroImageContentView.swift
@@ -19,13 +19,13 @@ struct GaroImageContentView: View {
             Image(.gentiLOGO)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(height: 44)
-                .padding(.top, 80)
+                .frame(height: UIScreen.isWiderThan375pt ? 44 : 24)
+                .padding(.top, UIScreen.isWiderThan375pt ? 80 : 40)
             
             Image(.charactor)
                 .resizable( )
                 .aspectRatio(contentMode: .fit)
-                .frame(height: 162)
+                .frame(height: UIScreen.isWiderThan375pt ? 162 : 100)
                 .padding(.top, 12)
             
             VStack {
@@ -50,7 +50,7 @@ struct GaroImageContentView: View {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(height: 212)
+                    .frame(height: UIScreen.isWiderThan375pt ? 212 : 180)
                     .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap) }
                     .cornerRadiusWithBorder(style: LinearGradient.borderGreen, radius: 15, lineWidth: 2)
                     .onTapGesture {
@@ -71,7 +71,7 @@ struct GaroImageContentView: View {
                 .pretendard(.small)
                 .foregroundStyle(.gray3)
         }
-        .frame(height: 640)
+        .frame(height: UIScreen.isWiderThan375pt ? 640 : 520)
         .frame(maxWidth: .infinity)
         .background(alignment: .top) {
             Rectangle()

--- a/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/SeroImageContentView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/CompletedPhoto/View/SeroImageContentView.swift
@@ -19,7 +19,7 @@ struct SeroImageContentView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(height: 44)
-                .padding(.top, 80)
+                .padding(.top, UIScreen.isWiderThan375pt ? 80 : 40)
             
             
             VStack {
@@ -44,7 +44,7 @@ struct SeroImageContentView: View {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(height: 360)
+                    .frame(height: UIScreen.isWiderThan375pt ? 360 : 260)
                     .addDownloadButton { self.viewModel.sendAction(.downloadButtonTap) }
                     .cornerRadiusWithBorder(style: LinearGradient.borderGreen, radius: 15, lineWidth: 2)
                     .onTapGesture {
@@ -66,7 +66,7 @@ struct SeroImageContentView: View {
                 .pretendard(.small)
                 .foregroundStyle(.gray3)
         }
-        .frame(height: 640)
+        .frame(height: UIScreen.isWiderThan375pt ? 640 : 520)
         .frame(maxWidth: .infinity)
         .background(alignment: .top) {
             Rectangle()

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/View/FirstGeneratorView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/View/FirstGeneratorView.swift
@@ -108,7 +108,7 @@ struct FirstGeneratorView: View {
                 .padding(.top, 13)
             
         } //:VSTACK
-        .padding(.top, 32)
+        .padding(.top, UIScreen.isWiderThan375pt ? 32 : 20)
     }
     private func addImageView() -> some View {
         VStack(spacing: 0) {
@@ -125,14 +125,14 @@ struct FirstGeneratorView: View {
             
             
             referenceImage()
-                .frame(width: 138, height: 138)
+                .frame(width: UIScreen.isWiderThan375pt ? 138 : 100, height: UIScreen.isWiderThan375pt ? 138 : 100)
             
             Text("(참고사진은 최대 1장 업로드 할 수 있어요)")
                 .pretendard(.description)
                 .foregroundStyle(.gray3)
                 .padding(.top, 5)
         } //:VSTACK
-        .padding(.top, 43)
+        .padding(.top, UIScreen.isWiderThan375pt ? 43 : 20)
     }
     @ViewBuilder
     private func referenceImage() -> some View {

--- a/Genti_iOS/Genti_iOS/Presentation/Generator/View/GenerateRequestCompleteView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Generator/View/GenerateRequestCompleteView.swift
@@ -26,7 +26,7 @@ struct GenerateRequestCompleteView: View {
                     Image("Genti_LOGO")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(height: 60)
+                        .frame(height: UIScreen.isWiderThan375pt ? 60 : 40)
                         .padding(.top, 44)
                     
                     
@@ -38,7 +38,7 @@ struct GenerateRequestCompleteView: View {
                     Image("Complete_charactor")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(height: 275)
+                        .frame(height: UIScreen.isWiderThan375pt ? 275 : 200)
 
                 } //:VSTACK
                 

--- a/Genti_iOS/Genti_iOS/Presentation/Splash/View/SplashView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/Splash/View/SplashView.swift
@@ -10,22 +10,24 @@ import SwiftUI
 import Lottie
 
 struct SplashView: View {
-    @State var splashViewModel: SplashViewModel
+    @State var viewModel: SplashViewModel
     
     var body: some View {
         LottieView(type: .splash)
             .playing()
             .animationDidFinish { _ in
-                self.splashViewModel.sendAction(.splashAnimationFinished)
+                self.viewModel.sendAction(.splashAnimationFinished)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             .ignoresSafeArea()
             .background {
-                Color.backgroundWhite
+                Color.white
+                    .ignoresSafeArea()
             }
+            .customAlert(alertType: $viewModel.state.showAlert)
     }
 }
 
 #Preview {
-    SplashView(splashViewModel: .init(router: .init(), splashUseCase: SplashUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl())))
+    SplashView(viewModel: .init(router: .init(), splashUseCase: SplashUseCaseImpl(authRepository: AuthRepositoryImpl(requestService: RequestServiceImpl()), userdefaultRepository: UserDefaultsRepositoryImpl())))
 }


### PR DESCRIPTION
## [#88] FIX : SE기기 대응 및 강제업데이트 기능 추가

## 🌱 작업한 내용
### 앱스토어에 se관련 문의가 와서 se기기 대응을 진행
<img width="300" alt="스크린샷 2024-09-12 오후 8 04 57" src="https://github.com/user-attachments/assets/8055fd6b-499a-407a-8c17-af583f571db4">

- UI가 깨지는 사진생성 flow와 완료되었을때 view에서 높이를 설정할때 아래의 타입변수를 활용해서 se와 se아닌 기기의 constrains를 다르게 설정
```swift
extension UIScreen {
    static var isWiderThan375pt: Bool { UIScreen.main.bounds.width > 375.0 }
}

```

### 추후에 진행될 업데이트를 위해 강제업데이트 기능 추가
- splashview의 애니메이션이 끝나면 아래의 flow로 진행
1. 앱업데이트가필요한지 판단
2. 1번에서 업데이트가 필요없다면 자동로그인여부에따라 로그인으로 갈지 메인으로갈지 결정됨
3. 1번에서 업데이트가 필요하다면 다음뷰로 넘어가지않고 업데이트 요청 알림을 띄움

> [!NOTE]  
> 강제업데이트 기준은 패치버전은 무시하고 릴리즈번호를 기준으로 판단

## 📮 관련 이슈

- Resolved: #88 
