### PR TITLE
[FEAT] 서버점검기능추가(#96)

### DIFF
--- a/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
+++ b/Genti_iOS/Genti_iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C00C3BE82CA7A6F1000C471B /* MaintenanceInfoResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C3BE72CA7A6F1000C471B /* MaintenanceInfoResponseDTO.swift */; };
+		C00C3BEA2CA7A7AF000C471B /* CheckInspectionTimeEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C3BE92CA7A7AF000C471B /* CheckInspectionTimeEntity.swift */; };
+		C00C3BEC2CA7E033000C471B /* UserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C3BEB2CA7E033000C471B /* UserState.swift */; };
+		C00C3BEE2CA7E04D000C471B /* InspectionTimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C00C3BED2CA7E04D000C471B /* InspectionTimeType.swift */; };
 		C0113D552C37C15200071BF6 /* ImageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0113D542C37C15200071BF6 /* ImageRepository.swift */; };
 		C0113D572C37C17400071BF6 /* ImageRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0113D562C37C17400071BF6 /* ImageRepositoryImpl.swift */; };
 		C0113D592C37C19800071BF6 /* HapticRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0113D582C37C19800071BF6 /* HapticRepository.swift */; };
@@ -223,6 +227,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		C00C3BE72CA7A6F1000C471B /* MaintenanceInfoResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaintenanceInfoResponseDTO.swift; sourceTree = "<group>"; };
+		C00C3BE92CA7A7AF000C471B /* CheckInspectionTimeEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInspectionTimeEntity.swift; sourceTree = "<group>"; };
+		C00C3BEB2CA7E033000C471B /* UserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserState.swift; sourceTree = "<group>"; };
+		C00C3BED2CA7E04D000C471B /* InspectionTimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectionTimeType.swift; sourceTree = "<group>"; };
 		C0113D542C37C15200071BF6 /* ImageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepository.swift; sourceTree = "<group>"; };
 		C0113D562C37C17400071BF6 /* ImageRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRepositoryImpl.swift; sourceTree = "<group>"; };
 		C0113D582C37C19800071BF6 /* HapticRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticRepository.swift; sourceTree = "<group>"; };
@@ -658,6 +666,7 @@
 		C04967A12C6490160097C732 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				C00C3BE92CA7A7AF000C471B /* CheckInspectionTimeEntity.swift */,
 				C0BCC4AC2C58842C009C89C4 /* SocialLoginEntity.swift */,
 				C0BCC4B02C58849E009C89C4 /* GentiTokenEntity.swift */,
 				C017C4662C1C3AA3009924C9 /* FeedEntity.swift */,
@@ -1003,6 +1012,7 @@
 				C017C4552C1C3AA3009924C9 /* GetUploadImageUrlDTO.swift */,
 				C01423E42C6D9B4900004683 /* SignInUserDTO.swift */,
 				C06F28FE2C95261B00A69575 /* OpenChatDTO.swift */,
+				C00C3BE72CA7A6F1000C471B /* MaintenanceInfoResponseDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -1147,6 +1157,8 @@
 		C04967D72C649A5F0097C732 /* Enum */ = {
 			isa = PBXGroup;
 			children = (
+				C00C3BED2CA7E04D000C471B /* InspectionTimeType.swift */,
+				C00C3BEB2CA7E033000C471B /* UserState.swift */,
 				C048A9002C51B63300026C80 /* Gender.swift */,
 				C095967F2C4DECEE00FC5ECC /* PopUpType.swift */,
 				C0113D8F2C3D3A0900071BF6 /* OnboardingStep.swift */,
@@ -1473,10 +1485,12 @@
 				C088F2F22C28D76500F92320 /* SeroImageContentView.swift in Sources */,
 				C028435E2C326CAE00B84566 /* UserRouter.swift in Sources */,
 				C017C4962C1C3AA3009924C9 /* PHAssetImageViewModel.swift in Sources */,
+				C00C3BEA2CA7A7AF000C471B /* CheckInspectionTimeEntity.swift in Sources */,
 				C0113D832C3BEAA400071BF6 /* LimitLengthModifier.swift in Sources */,
 				C017C4832C1C3AA3009924C9 /* PhotoRatio.swift in Sources */,
 				C0BCC4BA2C5885CC009C89C4 /* AuthRepositoryImpl.swift in Sources */,
 				C017C48D2C1C3AA3009924C9 /* MyImagesEntitiy.swift in Sources */,
+				C00C3BE82CA7A6F1000C471B /* MaintenanceInfoResponseDTO.swift in Sources */,
 				C0ADA6052C85409F00A583B8 /* AlbumRepository.swift in Sources */,
 				C0ADA6072C8540C200A583B8 /* AlbumRepositoryImpl.swift in Sources */,
 				C0113D812C3BEAA400071BF6 /* CustomAlertModifier.swift in Sources */,
@@ -1551,6 +1565,7 @@
 				C0113D862C3BEAA400071BF6 /* AddXmarkModifier.swift in Sources */,
 				C02843552C314C1E00B84566 /* FeedRouter.swift in Sources */,
 				C0113D902C3D3A0900071BF6 /* OnboardingStep.swift in Sources */,
+				C00C3BEE2CA7E04D000C471B /* InspectionTimeType.swift in Sources */,
 				C06F28F82C92FE4800A69575 /* UIScreen+Ext.swift in Sources */,
 				C049674D2C5C87FE0097C732 /* TabViewUseCase.swift in Sources */,
 				C0ADA6012C851C6C00A583B8 /* ImagePickerViewModel.swift in Sources */,
@@ -1579,6 +1594,7 @@
 				C0DE62702C6C4576005937B0 /* EventLogManager.swift in Sources */,
 				C017C3E02C1C39CE009924C9 /* SceneDelegate.swift in Sources */,
 				C0B192662C7C073800D198A2 /* PushAuthorizationPopup.swift in Sources */,
+				C00C3BEC2CA7E033000C471B /* UserState.swift in Sources */,
 				C0113D5B2C37C1A700071BF6 /* HapticRepositoryImpl.swift in Sources */,
 				C017C4202C1C3A62009924C9 /* GentiApp.swift in Sources */,
 				C0BCC4AD2C58842C009C89C4 /* SocialLoginEntity.swift in Sources */,
@@ -1781,7 +1797,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Genti.iOS.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1823,7 +1839,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Genti.iOS.2024;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Genti_iOS/Genti_iOS/Data/DTO/MaintenanceInfoResponseDTO.swift
+++ b/Genti_iOS/Genti_iOS/Data/DTO/MaintenanceInfoResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  MaintenanceInfoResponseDTO.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 9/28/24.
+//
+
+import Foundation
+
+struct MaintenanceInfoResponseDTO: Codable {
+    let status: Bool
+    var message: String?
+}
+
+extension MaintenanceInfoResponseDTO {
+    var toEntitiy: CheckInspectionTimeEntity {
+        return .init(canMake: self.status, message: self.message)
+    }
+}

--- a/Genti_iOS/Genti_iOS/Data/EndPoints/UserRouter.swift
+++ b/Genti_iOS/Genti_iOS/Data/EndPoints/UserRouter.swift
@@ -9,14 +9,6 @@ import Foundation
 
 import Alamofire
 
-enum UserState {
-    case inProgress
-    case canMake
-    case awaitUserVerification(CompletedPhotoEntity)
-    case canceled(requestId: Int)
-    case error
-}
-
 enum UserRouter: URLRequestConvertible {
     
     case fetchMyPictures
@@ -26,10 +18,11 @@ enum UserRouter: URLRequestConvertible {
     case checkCompletedImage(responeId: Int)
     case checkCanceledImage(requestId: Int)
     case fetchOpenChatInfo
+    case getInspectionTimeInfo
     
     var method: HTTPMethod {
         switch self {
-        case .fetchMyPictures, .getUserState, .checkCanceledImage, .fetchOpenChatInfo:
+        case .fetchMyPictures, .getUserState, .checkCanceledImage, .fetchOpenChatInfo, .getInspectionTimeInfo:
             return .get
         case .reportPicture, .ratePicture, .checkCompletedImage:
             return .post
@@ -38,7 +31,7 @@ enum UserRouter: URLRequestConvertible {
     
     var headers: HTTPHeaders {
         switch self {
-        case .fetchMyPictures, .reportPicture, .ratePicture, .getUserState, .checkCompletedImage, .checkCanceledImage, .fetchOpenChatInfo:
+        case .fetchMyPictures, .reportPicture, .ratePicture, .getUserState, .checkCompletedImage, .checkCanceledImage, .fetchOpenChatInfo, .getInspectionTimeInfo:
             return []
         }
     }
@@ -64,6 +57,8 @@ enum UserRouter: URLRequestConvertible {
             return "/api/v1/users/picture-generate-requests/\(requestId)/confirm-cancel-status"
         case .fetchOpenChatInfo:
             return "/api/v1/open-chat"
+        case .getInspectionTimeInfo:
+            return "/api/v1/maintenance"
         }
     }
     
@@ -85,7 +80,7 @@ enum UserRouter: URLRequestConvertible {
             var parameters: [String: Any] = [:]
             parameters["star"] = rate
             urlRequest = try URLEncoding(destination: .queryString).encode(urlRequest, with: parameters)
-        case .getUserState, .checkCompletedImage, .checkCanceledImage, .fetchMyPictures, .fetchOpenChatInfo:
+        case .getUserState, .checkCompletedImage, .checkCanceledImage, .fetchMyPictures, .fetchOpenChatInfo, .getInspectionTimeInfo:
             return urlRequest
         }
         return urlRequest

--- a/Genti_iOS/Genti_iOS/Data/Repositories/UserRepositoryImpl.swift
+++ b/Genti_iOS/Genti_iOS/Data/Repositories/UserRepositoryImpl.swift
@@ -8,12 +8,18 @@
 import Foundation
 
 final class UserRepositoryImpl: UserRepository {
-    
+
     let requestService: RequestService
     
     init(requestService: RequestService) {
         self.requestService = requestService
     }
+    
+    func checkInspectionTime() async throws -> CheckInspectionTimeEntity {
+        let dto: MaintenanceInfoResponseDTO = try await requestService.fetchResponse(for: UserRouter.getInspectionTimeInfo)
+        return dto.toEntitiy
+    }
+    
     
     func getOpenChatInfo() async throws -> GentiOpenChatAgreementType {
         let dto: OpenChatDTO = try await requestService.fetchResponse(for: UserRouter.fetchOpenChatInfo)

--- a/Genti_iOS/Genti_iOS/Domain/Entities/CheckInspectionTimeEntity.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Entities/CheckInspectionTimeEntity.swift
@@ -1,0 +1,12 @@
+//
+//  CheckInspectionTimeEntity.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 9/28/24.
+//
+
+
+struct CheckInspectionTimeEntity {
+    let canMake: Bool
+    var message: String?
+}

--- a/Genti_iOS/Genti_iOS/Domain/Interfaces/UserRepository.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Interfaces/UserRepository.swift
@@ -17,4 +17,5 @@ protocol UserRepository {
     func checkCanceledImage(requestId: Int) async throws
     func checkUserHasCanceledOrAwaitedRequest() async throws -> Bool
     func getOpenChatInfo() async throws -> GentiOpenChatAgreementType
+    func checkInspectionTime() async throws -> CheckInspectionTimeEntity
 }

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
@@ -23,6 +23,7 @@ enum AlertType {
     case photoRequestCanceled(action: AlertAction?)
     case pushAuthorization(action: AlertAction?)
     case update(action: AlertAction?)
+    case InspectionTime(title: String?)
     
     var data: Alert {
         switch self {
@@ -79,6 +80,8 @@ enum AlertType {
             return .init(title: "일시적인 오류 발생", message: "앱을 종료 후 다시 시도해주세요\n로그인화면으로 이동합니다", actions: [.init(title: "확인", action: action)])
         case .update(action: let action):
             return .init(title: "업데이트 알림", message: "더 나은 서비스를 위해 필요한 업데이트가 있습니다!\n업데이트해주시겠어요?", actions: [.init(title: "업데이트하러 가기", action: action)])
+        case .InspectionTime(let title):
+            return .init(title: "서비스 점검 중", message: "더 나은 서비스를 위해 점검중입니다\n\(title ?? "하루 후에 이용해주세요")", actions: [.init(title: "확인", action: nil)])
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/AlertType.swift
@@ -81,7 +81,7 @@ enum AlertType {
         case .update(action: let action):
             return .init(title: "업데이트 알림", message: "더 나은 서비스를 위해 필요한 업데이트가 있습니다!\n업데이트해주시겠어요?", actions: [.init(title: "업데이트하러 가기", action: action)])
         case .InspectionTime(let title):
-            return .init(title: "서비스 점검 중", message: "더 나은 서비스를 위해 점검중입니다\n\(title ?? "하루 후에 이용해주세요")", actions: [.init(title: "확인", action: nil)])
+            return .init(title: "서비스 점검 중", message: "\(title ?? "하루 후에 이용해주세요")", actions: [.init(title: "확인", action: nil)])
         }
     }
 }

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/InspectionTimeType.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/InspectionTimeType.swift
@@ -1,0 +1,12 @@
+//
+//  InspectionTimeType.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 9/28/24.
+//
+
+
+enum InspectionTimeType {
+    case canMake
+    case cantMake(title: String?)
+}

--- a/Genti_iOS/Genti_iOS/Domain/Model/Enum/UserState.swift
+++ b/Genti_iOS/Genti_iOS/Domain/Model/Enum/UserState.swift
@@ -1,0 +1,15 @@
+//
+//  UserState.swift
+//  Genti_iOS
+//
+//  Created by uiskim on 9/28/24.
+//
+
+
+enum UserState {
+    case inProgress
+    case canMake
+    case awaitUserVerification(CompletedPhotoEntity)
+    case canceled(requestId: Int)
+    case error
+}

--- a/Genti_iOS/Genti_iOS/Domain/UseCases/TabViewUseCase.swift
+++ b/Genti_iOS/Genti_iOS/Domain/UseCases/TabViewUseCase.swift
@@ -12,6 +12,7 @@ protocol TabViewUseCase {
     func checkCanceledImage(requestId: Int) async throws
     func getSavedBackgroundPush() async throws -> BackgroundPushType?
     func checkOpenChat() async throws -> GentiOpenChatAgreementType
+    func checkInspectionTime() async throws -> InspectionTimeType
 }
 
 final class TabViewUseCaseImpl: TabViewUseCase {
@@ -22,6 +23,11 @@ final class TabViewUseCaseImpl: TabViewUseCase {
     init(userRepository: UserRepository, userdefaultRepository: UserDefaultsRepository) {
         self.userRepository = userRepository
         self.userdefaultRepository = userdefaultRepository
+    }
+    
+    func checkInspectionTime() async throws -> InspectionTimeType {
+        let inspectionTimeInfo = try await userRepository.checkInspectionTime()
+        return inspectionTimeInfo.canMake ? .canMake : .cantMake(title: inspectionTimeInfo.message)
     }
     
     func getUserState() async throws -> UserState {

--- a/Genti_iOS/Genti_iOS/Instructure/Constants.swift
+++ b/Genti_iOS/Genti_iOS/Instructure/Constants.swift
@@ -9,8 +9,8 @@ import Foundation
 import UIKit
 
 enum Constants {
-    static let baseURL = "https://api.genti.kr"
-//    static let baseURL = "https://dev.genti.kr"
+//    static let baseURL = "https://api.genti.kr"
+    static let baseURL = "https://dev.genti.kr"
     
     static let randomImage = "https://picsum.photos/600/600"
     

--- a/Genti_iOS/Genti_iOS/Presentation/TabView/View/GentiTabView.swift
+++ b/Genti_iOS/Genti_iOS/Presentation/TabView/View/GentiTabView.swift
@@ -25,11 +25,6 @@ struct GentiTabView: View {
         .onAppear {
             self.viewModel.sendAction(.viewWillAppear)
         }
-        .overlay(alignment: .center) {
-            if viewModel.state.isLoading {
-                LoadingView()
-            }
-        }
         .customAlert(alertType: $viewModel.state.showAlert)
         .onNotificationRecieved(name: Notification.Name(rawValue: "PushNotificationReceived")) { _ in
             self.viewModel.sendAction(.pushReceived)


### PR DESCRIPTION
## [#96] FEAT : 서버점검기능추가

## 🌱 작업한 내용
### 서버점검기능 추가
- sprint2에 들어가기 전에 기획쪽 팀원들이 쉬지도 못하고 매일매일 사진을 만들고 있다는걸 알게되었고 기획측에서는 만약에 휴가라던가 사진생성을 못하게되면 간단하게 "서버를 내린다"라고 생각을 하고 있다는걸 알게되었습니다
- 하지만 그렇게 되면 앱에 접근 자체가 불가능해지고 피드를 본다거나 내가 이미 만든사진을 다운로드하는 기능은 휴가때 안되는 기능인 "사진생성"과 아무런 관련이 없기에 사진생성만 막는 방식으로 기능을 추가하면 좋을거같다는 생각이들어 backend에 기능을 제안하고 기획측의 동의를 받아 기획하고 개발하된 기능

## 🌱 PR Point
### 서버점검 기능 명세
- 사진생성flow가 시작되는 타이밍(탭바의 카메라 버튼을 눌렀을 때)에 점검중인지 확인한다
- 점검중이 아니라면 기존의 방식대로 userstate를 파악해서 적절한 UI를 보여준다
- 점검중이라면 점검 message를 서버에서 받아서(점검때마다 시간을 실시간으로 알려주고싶다고 함) 알림으로 띄워준다
- API를 통해 아래 두가지타입의 결과를 반환해준다
```swift
enum InspectionTimeType {
    case canMake
    case cantMake(title: String?)
}
```
- 해당 결과에따라 canMake일때는 기존의 Userstate로직을 실행해주고 cantMake라면 title을 그대로 alert에 넣어준다
```swift
@MainActor
func handleUserState() async {
    do {
        switch try await tabViewUseCase.checkInspectionTime() {
        case .canMake:
            ...기존의 UserState로직...
        case .cantMake(let title):
            self.state.showAlert = .InspectionTime(title: title)
        }
    } catch(let error) {
        handleError(error)
    }
}
```
## 📸 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 점검중일 때 | <img src=https://github.com/user-attachments/assets/1e7a0994-9ae9-464d-9c6f-8d32c34361df width="300"/> |


## 📮 관련 이슈

- Resolved: #96 
